### PR TITLE
Improved: code to set the job status as draft after cancelling the job and fetching the latest job information, and added conditional chaining for checking job length(#25k2nxy)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -425,7 +425,7 @@ const actions: ActionTree<JobState, RootState> = {
     return resp;
   },
 
-  async cancelJob({ dispatch }, job) {
+  async cancelJob({ dispatch, state }, job) {
     let resp;
 
     try {
@@ -438,6 +438,14 @@ const actions: ActionTree<JobState, RootState> = {
       });
       if (resp.status == 200 && !hasError(resp)) {
         showToast(translate('Service updated successfully'))
+        state.cached[job.systemJobEnumId].statusId = 'SERVICE_DRAFT'
+        state.cached[job.systemJobEnumId].status = 'SERVICE_DRAFT'
+        dispatch('fetchJobs', {
+          inputFields: {
+            'systemJobEnumId': job.systemJobEnumId,
+            'systemJobEnumId_op': 'equals'
+          }
+        })
       } else {
         showToast(translate('Something went wrong'))
       }

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -25,7 +25,7 @@
       <main>
         <section v-if="segmentSelected === 'pending'">
           <!-- Empty state -->
-          <div v-if="pendingJobs.length === 0">
+          <div v-if="pendingJobs?.length === 0">
             <p class="ion-text-center">{{ $t("There are no jobs pending right now")}}</p>
           </div>
 
@@ -78,7 +78,7 @@
 
         <section v-if="segmentSelected === 'running'">
           <!-- Empty state -->
-          <div v-if="runningJobs.length === 0">
+          <div v-if="runningJobs?.length === 0">
             <p class="ion-text-center">{{ $t("There are no jobs running right now")}}</p>
           </div>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
- Unable to schedule a job after canceling it using the toggle
- Having issue `Cannot read property of undefined (reading length)`

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Changed job status to draft after canceling a job
- Added conditional chaining to check for job information before finding it's length


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)