### PR TITLE
Improved code by displaying only store name in place of whole eCom store data(#28zrvv1)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -27,7 +27,7 @@
         <ion-item lines="none">
           <ion-label class="ion-text-wrap">
             <p class="overline">{{ instanceUrl }}</p>
-            {{ eComStore }}
+            {{ eComStore.storeName }}
           </ion-label>
           <ion-note slot="end">{{ userProfile.userTimeZone }}</ion-note>
         </ion-item>


### PR DESCRIPTION
### Related Issues
#116 

Closes #116 

### Short Description and Why It's Useful
Currently whole eCom store data was getting displayed. But we have now specified that we only want to display store name from eCom store


### Screenshots of Visual Changes before/after (If There Are Any)
**Before:**
![store-name-before](https://user-images.githubusercontent.com/82817616/165460299-90235dcc-c492-4c1b-b9af-4156e72e8563.png)

**After:**
![store-name-after](https://user-images.githubusercontent.com/82817616/165460326-d5603014-ec04-4b59-be16-fb9d1867f448.png)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)