### PR TITLE
Improved: code so that user should not be able to schedule job without selecting product store (#28zthxn).

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -87,6 +87,7 @@
   "Performing a hard sync from HotWax Commerce to Shopify is useful for eliminating any discrepencies.": "Performing a hard sync from HotWax Commerce to Shopify is useful for eliminating any discrepencies.",
   "Payment status": "Payment status",
   "Pending": "Pending",
+  "Please select product store before scheduling the job.": "Please select product store before scheduling the job.",
   "Pre-order": "Pre-order",
   "Pre-orders": "Pre-orders",
   "Pipeline": "Pipeline",

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -319,17 +319,21 @@ const actions: ActionTree<JobState, RootState> = {
     job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
 
     try {
-      resp = await JobService.scheduleJob({ ...job.runtimeData, ...payload });
-      if (resp.status == 200 && !hasError(resp)) {
-        showToast(translate('Service has been scheduled'))
-        dispatch('fetchJobs', {
-          inputFields: {
-            'systemJobEnumId': payload.systemJobEnumId,
-            'systemJobEnumId_op': 'equals'
-          }
-        })
+      if(payload.jobFields?.productStoreId) {
+        resp = await JobService.scheduleJob({ ...job.runtimeData, ...payload });
+        if (resp.status == 200 && !hasError(resp)) {
+          showToast(translate('Service has been scheduled'))
+          dispatch('fetchJobs', {
+            inputFields: {
+              'systemJobEnumId': payload.systemJobEnumId,
+              'systemJobEnumId_op': 'equals'
+            }
+          })
+        } else {
+          showToast(translate('Something went wrong'))
+        }
       } else {
-        showToast(translate('Something went wrong'))
+        showToast(translate('Please select product store before scheduling the job.'))
       }
     } catch (err) {
       showToast(translate('Something went wrong'))


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #119 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved code so that user can not schedule job without selecting product store, if he is trying to schedule the job showed a toast `Please select product store before scheduling the job` on screen.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://user-images.githubusercontent.com/52008359/165695669-c9a5166c-4524-4654-9b5c-058f7aef7ef2.png)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)