### PR TITLE
Updated DateTime code for job history modal and history segment(#2894bh1)

### DIFF
--- a/src/components/JobHistoryModal.vue
+++ b/src/components/JobHistoryModal.vue
@@ -18,7 +18,10 @@
     <div v-else>
       <ion-list>
         <ion-item v-for="(job, index) in jobHistory" :key="index">
-          <ion-label>{{ job.runTime ? getTime(job.runTime) : "-" }}</ion-label>
+          <ion-label>
+            {{ job.runTime ? getTime(job.runTime) : "-" }}
+            <p v-if="job.runTime">{{ getDate(job.runTime) }}</p>
+          </ion-label>
           <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ getStatusDesc(job.statusId) }}</ion-badge>
         </ion-item>
       </ion-list>
@@ -36,6 +39,7 @@ import {
   IonIcon,
   IonItem,
   IonLabel,
+  IonList,
   IonTitle,
   IonToolbar,
   modalController
@@ -58,6 +62,7 @@ export default defineComponent({
     IonIcon,
     IonItem,
     IonLabel,
+    IonList,
     IonTitle,
     IonToolbar,
   },
@@ -78,8 +83,11 @@ export default defineComponent({
     closeModal() {
       modalController.dismiss({ dismissed: true });
     },
-    getTime (time: any) {
-      return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
+    getDate (runTime: any) {
+      return DateTime.fromMillis(runTime).toLocaleString(DateTime.DATE_MED);
+    },
+    getTime (runTime: any) {
+      return DateTime.fromMillis(runTime).toLocaleString(DateTime.TIME_SIMPLE);
     },
     async fetchJobHistory() {
       let resp;

--- a/src/components/JobHistoryModal.vue
+++ b/src/components/JobHistoryModal.vue
@@ -16,10 +16,12 @@
     </div>
 
     <div v-else>
-      <ion-item v-for="(job, index) in jobHistory" :key="index">
-        <ion-label>{{ job.runTime ? getTime(job.runTime) : "-" }}</ion-label>
-        <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ getStatusDesc(job.statusId) }}</ion-badge>
-      </ion-item>
+      <ion-list>
+        <ion-item v-for="(job, index) in jobHistory" :key="index">
+          <ion-label>{{ job.runTime ? getTime(job.runTime) : "-" }}</ion-label>
+          <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ getStatusDesc(job.statusId) }}</ion-badge>
+        </ion-item>
+      </ion-list>
     </div>
   </ion-content>
 </template>
@@ -77,7 +79,7 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true });
     },
     getTime (time: any) {
-      return DateTime.fromMillis(time).toLocaleString(DateTime.TIME_SIMPLE);
+      return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
     },
     async fetchJobHistory() {
       let resp;

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -46,7 +46,7 @@ const actions: ActionTree<JobState, RootState> = {
         "statusId_op": "in",
         "systemJobEnumId_op": "not-empty"
       },
-      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId", "cancelDateTime", "finishDateTime" ],
+      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId", "cancelDateTime", "finishDateTime", "startDateTime" ],
       "entityName": "JobSandbox",
       "noConditionFind": "Y",
       "viewSize": payload.viewSize,
@@ -88,7 +88,7 @@ const actions: ActionTree<JobState, RootState> = {
     await JobService.fetchJobInformation({
       "inputFields": {
         "productStoreId": payload.eComStoreId,
-        "statusId": "SERVICE_RUNNING",
+        "statusId": ["SERVICE_RUNNING", "SERVICE_QUEUED"],
         "systemJobEnumId_op": "not-empty"
       },
       "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName" ],
@@ -148,7 +148,7 @@ const actions: ActionTree<JobState, RootState> = {
           if(payload.viewIndex && payload.viewIndex > 0){
             jobs = state.pending.list.concat(resp.data.docs);
           }
-          
+
           commit(types.JOB_PENDING_UPDATED, { jobs, total });
           const tempExprList = [] as any;
           const enumIds = [] as any;

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -88,8 +88,13 @@ const actions: ActionTree<JobState, RootState> = {
     await JobService.fetchJobInformation({
       "inputFields": {
         "productStoreId": payload.eComStoreId,
-        "statusId": ["SERVICE_RUNNING", "SERVICE_QUEUED"],
-        "systemJobEnumId_op": "not-empty"
+        "systemJobEnumId_op": "not-empty",
+        "statusId_fld0_value": "SERVICE_RUNNING",
+        "statusId_fld0_op": "equals",
+        "statusId_fld0_grp": "1",
+        "statusId_fld1_value": "SERVICE_QUEUED",
+        "statusId_fld1_op": "equals",
+        "statusId_fld1_grp": "2",
       },
       "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName" ],
       "entityName": "JobSandbox",

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -148,6 +148,7 @@ const actions: ActionTree<JobState, RootState> = {
           if(payload.viewIndex && payload.viewIndex > 0){
             jobs = state.pending.list.concat(resp.data.docs);
           }
+          
           commit(types.JOB_PENDING_UPDATED, { jobs, total });
           const tempExprList = [] as any;
           const enumIds = [] as any;

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -153,7 +153,6 @@ const actions: ActionTree<JobState, RootState> = {
           if(payload.viewIndex && payload.viewIndex > 0){
             jobs = state.pending.list.concat(resp.data.docs);
           }
-
           commit(types.JOB_PENDING_UPDATED, { jobs, total });
           const tempExprList = [] as any;
           const enumIds = [] as any;

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -46,7 +46,7 @@ const actions: ActionTree<JobState, RootState> = {
         "statusId_op": "in",
         "systemJobEnumId_op": "not-empty"
       },
-      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId" ],
+      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId", "cancelDateTime", "finishDateTime" ],
       "entityName": "JobSandbox",
       "noConditionFind": "Y",
       "viewSize": payload.viewSize,
@@ -148,7 +148,6 @@ const actions: ActionTree<JobState, RootState> = {
           if(payload.viewIndex && payload.viewIndex > 0){
             jobs = state.pending.list.concat(resp.data.docs);
           }
-          
           commit(types.JOB_PENDING_UPDATED, { jobs, total });
           const tempExprList = [] as any;
           const enumIds = [] as any;

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -96,7 +96,7 @@ const actions: ActionTree<JobState, RootState> = {
         "statusId_fld1_op": "equals",
         "statusId_fld1_grp": "2",
       },
-      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName" ],
+      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId" ],
       "entityName": "JobSandbox",
       "noConditionFind": "Y",
       "viewSize": payload.viewSize,
@@ -110,7 +110,9 @@ const actions: ActionTree<JobState, RootState> = {
           if(payload.viewIndex && payload.viewIndex > 0){
             jobs = state.running.list.concat(resp.data.docs);
           }
-          
+          jobs.map((job: any) => {
+            job['statusDesc'] = this.state.util.statusDesc[job.statusId];
+          })
           commit(types.JOB_RUNNING_UPDATED, { jobs, total });
           const tempExprList = [] as any;
           const enumIds = [] as any;

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -39,7 +39,7 @@
             <ion-card v-for="job in pendingJobs" :key="job.jobId" @click="viewJobConfiguration(job)" :button="isDesktop">
               <ion-card-header>
                 <ion-card-title>{{ getEnumName(job.systemJobEnumId) }}</ion-card-title>
-                <ion-badge v-if="job.runTime" color="dark">{{ timeTillJob(job.runTime)}}</ion-badge>
+                <ion-badge v-if="job.runTime" color="dark">{{ timeFromNow(job.runTime)}}</ion-badge>
               </ion-card-header>
 
               <ion-item lines="none">
@@ -158,7 +158,7 @@
                 <ion-card-title>{{ getEnumName(job.systemJobEnumId) }}</ion-card-title>
               </div>
               <div>
-                <ion-badge v-if="job.cancelDateTime || job.finishDateTime" color="dark">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ?  timeTillJob(job.cancelDateTime) : timeTillJob(job.finishDateTime) }}</ion-badge>
+                <ion-badge v-if="job.cancelDateTime || job.finishDateTime" color="dark">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ?  timeFromNow(job.cancelDateTime) : timeFromNow(job.finishDateTime) }}</ion-badge>
                 <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ job.statusDesc }}</ion-badge>
               </div>
             </ion-card-header>
@@ -320,7 +320,7 @@ export default defineComponent({
     getTime (time: any) {
       return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
     },
-    timeTillJob (time: any) {
+    timeFromNow (time: any) {
       const timeDiff = DateTime.fromMillis(time).diff(DateTime.local());
       return DateTime.local().plus(timeDiff).toRelative();
     },

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -105,7 +105,7 @@
                   <ion-card-subtitle class="overline">{{ job.parentJobId }}</ion-card-subtitle>
                   <ion-card-title>{{ getEnumName(job.systemJobEnumId) }}</ion-card-title>
                 </div>
-                <ion-badge color="dark">Running</ion-badge>
+                <ion-badge color="dark">{{ job.statusDesc }}</ion-badge>
               </ion-card-header>
 
               <ion-item lines="none">
@@ -307,10 +307,17 @@ export default defineComponent({
   methods: {
     getJobExecutionTime(startTime: any, endTime: any){
       if (startTime && endTime) {
-        return DateTime.fromMillis(endTime).diff( DateTime.fromMillis(startTime)).toFormat("hh:mm:ss")
-      } else {
-        return
+        const timeDiff = DateTime.fromMillis(endTime).diff( DateTime.fromMillis(startTime))
+        const hours =  timeDiff.hours
+        const minutes = timeDiff.minutes
+        const seconds =  timeDiff
+        let format = ""
+        if(hours) format += "hh 'hr' "
+        if(minutes) format += "mm 'min' "
+        if(seconds) format += "ss 'sec'"
+        if (format) return timeDiff.toFormat(format);
       }
+      return
     },
     async copyJobInformation(job: any) {
       const { Clipboard } = Plugins;

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -158,7 +158,7 @@
                 <ion-card-title>{{ getEnumName(job.systemJobEnumId) }}</ion-card-title>
               </div>
               <div>
-                <ion-badge v-if="job.cancelDateTime || job.finishDateTime" color="dark">{{ job.statusDesc == "Cancelled" || job.statusDesc == "Crashed" ?  timeTillJob(job.cancelDateTime) : timeTillJob(job.finishDateTime) }}</ion-badge>
+                <ion-badge v-if="job.cancelDateTime || job.finishDateTime" color="dark">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ?  timeTillJob(job.cancelDateTime) : timeTillJob(job.finishDateTime) }}</ion-badge>
                 <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ job.statusDesc }}</ion-badge>
               </div>
             </ion-card-header>

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -173,7 +173,7 @@
               <ion-label class="ion-text-wrap">
                 {{ job.runTime ? getTime(job.runTime) : "-"  }}
               </ion-label>
-              <ion-note slot="end">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ? getRunTime(job.startDateTime, job.cancelDateTime) : getRunTime(job.startDateTime, job.finishDateTime) }}</ion-note>
+              <ion-note slot="end">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ? getJobExecutionTime(job.startDateTime, job.cancelDateTime) : getJobExecutionTime(job.startDateTime, job.finishDateTime) }}</ion-note>
             </ion-item>
 
             <ion-item>
@@ -305,7 +305,7 @@ export default defineComponent({
     })
   },
   methods: {
-    getRunTime(startTime: any, endTime: any){
+    getJobExecutionTime(startTime: any, endTime: any){
       if (startTime && endTime) {
         return DateTime.fromMillis(endTime).diff( DateTime.fromMillis(startTime)).toFormat("hh:mm:ss")
       } else {

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -170,7 +170,10 @@
             </ion-item>
             <ion-item>
               <ion-icon slot="start" :icon="timeOutline" />
-              <ion-label class="ion-text-wrap">{{ job.runTime ? getTime(job.runTime) : "-"  }}</ion-label>
+              <ion-label class="ion-text-wrap">
+                {{ job.runTime ? getTime(job.runTime) : "-"  }}
+              </ion-label>
+              <ion-note slot="end">{{ job.statusId == "SERVICE_CANCELLED" || job.statusId == "SERVICE_CRASHED" ? getRunTime(job.startDateTime, job.cancelDateTime) : getRunTime(job.startDateTime, job.finishDateTime) }}</ion-note>
             </ion-item>
 
             <ion-item>
@@ -218,6 +221,7 @@ import {
   IonItem,
   IonLabel,
   IonMenuButton,
+  IonNote,
   IonPage,
   IonRefresher,
   IonRefresherContent,
@@ -254,6 +258,7 @@ export default defineComponent({
     IonItem,
     IonLabel,
     IonMenuButton,
+    IonNote,
     IonPage,
     IonRefresher,
     IonRefresherContent,
@@ -300,6 +305,13 @@ export default defineComponent({
     })
   },
   methods: {
+    getRunTime(startTime: any, endTime: any){
+      if (startTime && endTime) {
+        return DateTime.fromMillis(endTime).diff( DateTime.fromMillis(startTime)).toFormat("hh:mm:ss")
+      } else {
+        return
+      }
+    },
     async copyJobInformation(job: any) {
       const { Clipboard } = Plugins;
       const jobDetails = `jobId: ${job.jobId}, jobName: ${this.getEnumName(job.systemJobEnumId)}, jobDescription: ${this.getEnumDescription(job.systemJobEnumId)}`;
@@ -318,7 +330,7 @@ export default defineComponent({
       return jobHistoryModal.present();
     },
     getTime (time: any) {
-      return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
+      return DateTime.fromMillis(time).toLocaleString(DateTime.TIME_SIMPLE);
     },
     timeFromNow (time: any) {
       const timeDiff = DateTime.fromMillis(time).diff(DateTime.local());

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -158,7 +158,7 @@
                 <ion-card-title>{{ getEnumName(job.systemJobEnumId) }}</ion-card-title>
               </div>
               <div>
-                <ion-badge v-if="job.runTime" color="dark">{{ timeTillJob(job.runTime)}}</ion-badge>
+                <ion-badge v-if="job.cancelDateTime || job.finishDateTime" color="dark">{{ job.statusDesc == "Cancelled" || job.statusDesc == "Crashed" ?  timeTillJob(job.cancelDateTime) : timeTillJob(job.finishDateTime) }}</ion-badge>
                 <ion-badge v-if="job.statusId" :color="job.statusId === 'SERVICE_FINISHED' ? 'success' : 'danger'">{{ job.statusDesc }}</ion-badge>
               </div>
             </ion-card-header>
@@ -318,7 +318,7 @@ export default defineComponent({
       return jobHistoryModal.present();
     },
     getTime (time: any) {
-      return DateTime.fromMillis(time).toLocaleString(DateTime.TIME_SIMPLE);
+      return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
     },
     timeTillJob (time: any) {
       const timeDiff = DateTime.fromMillis(time).diff(DateTime.local());


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated date time format in job history modal and history segment.
Displayed cancel/finish time instead of run time in history segment.
Made status description dynamic in running segment.
Updated the action for fetching running jobs


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2022-04-29 17-05-41](https://user-images.githubusercontent.com/58461801/165937054-546d2be1-7b37-48af-9256-2611e200921a.png)

![Screenshot from 2022-04-29 17-04-03](https://user-images.githubusercontent.com/58461801/165936873-c5cdb629-f72d-4d1e-8314-470742d6d13b.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)