### PR TITLE
Improved: code to add support to copy and see job information on history and running segment (#2a7yjq9).

### DIFF
--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -127,6 +127,12 @@
                 <ion-icon slot="start" :icon="codeWorkingOutline" />
                 <ion-label class="ion-text-wrap">{{ job.serviceName }}</ion-label>
               </ion-item>
+
+              <ion-item>
+                <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
+                  <ion-icon slot="icon-only" :icon="copyOutline" />
+                </ion-button>
+              </ion-item>
             </ion-card>
 
             <ion-refresher slot="fixed" @ionRefresh="refreshJobs($event)">
@@ -186,6 +192,11 @@
               <ion-label class="ion-text-wrap">{{ job.serviceName }}</ion-label>
             </ion-item>
 
+            <ion-item>
+              <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
+                <ion-icon slot="icon-only" :icon="copyOutline" />
+              </ion-button>
+            </ion-item>
           </ion-card>
 
           <ion-refresher slot="fixed" @ionRefresh="refreshJobs($event)">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented functionality to add support to copy and see job information on the history on running and history segment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://user-images.githubusercontent.com/52008359/167579534-6ee86feb-16d4-4723-a919-7a69e36a0569.png)

![image](https://user-images.githubusercontent.com/52008359/167579361-9b593e17-8f2b-4f5d-8f50-98f8166809dd.png)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)