### PR TITLE
Improved: code to add 'None' option at bottom of product stores list and select first productStore by default (#2cjevda).

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -65,14 +65,18 @@ const actions: ActionTree<UserState, RootState> = {
         "noConditionFind": "Y"
       }
 
-      await dispatch('getEComStores', payload).then((stores: any) => { resp.data.stores = [{
-          productStoreId: "",
-          storeName: "None"
-        }, ...(stores ? stores : [])]
+      await dispatch('getEComStores', payload).then((stores: any) => {
+        resp.data.stores = [
+          ...(stores ? stores : []),
+          {
+            productStoreId: "",
+            storeName: "None"
+          }
+        ]
       })
 
       this.dispatch('util/getServiceStatusDesc')
-
+      commit(types.USER_CURRENT_ECOM_STORE_UPDATED, resp.data?.stores[0]);
       commit(types.USER_INFO_UPDATED, resp.data);
     }
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
:- Worked on improving the code to move 'None' option at bottom of the product stores list and select the first product store by default in all cases.
**Reason :** Right now when a user logs into the app "None" product store is selected by default. This option is not relevant in most cases anymore but we want to keep it around incase there are jobs we need to manage that are not associated with a specific product store.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
https://user-images.githubusercontent.com/52008359/168738342-8ab6aaf4-37a1-49ac-9edf-3d23a241ace9.mp4


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)