### PR TITLE
Fixed: Pending jobs of Pipeline page are not updated on login(#2cxv1xh)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -17,7 +17,7 @@ const actions: ActionTree<UserState, RootState> = {
       if (resp.status === 200 && resp.data) {
         if (resp.data.token) {
             commit(types.USER_TOKEN_CHANGED, { newToken: resp.data.token })
-            dispatch('getProfile')
+            await dispatch('getProfile')
             dispatch('getShopifyConfig')
             return resp.data;
         } else if (hasError(resp)) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When the user logins, as the product stores are not yet available it is sent empty, and wrong job list is fetched. Users should be logged in only after current product store is set

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)

https://user-images.githubusercontent.com/44576058/169495573-a1d41b47-5c7b-4211-8185-65a78764c76a.mp4

