### PR TITLE
Stop selection of job to filter while unpinning jobs

### DIFF
--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -367,7 +367,8 @@ export default defineComponent({
     },
     updateSelectedPinnedJob(jobEnumId: any) {
       const index = (this as any).selectedPinnedJobs.indexOf(jobEnumId);
-      if (index != -1) {
+      const pinnedJobs = new Set(this.getPinnedJobs);
+      if (index != -1 || !pinnedJobs.has(jobEnumId)) {
         (this as any).selectedPinnedJobs.splice(index, 1);
       } else {
         (this as any).selectedPinnedJobs.push(jobEnumId)


### PR DESCRIPTION
### Related Issues
Stop selection of job to filter while unpin jobs

### Short Description and Why It's Useful 

### Screenshots of Visual Changes before/after (If There Are Any)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)