### PR TITLE
Fixed: code to get 'eComStores' in 'getProfile' action instead of calling 'getEcomStores' action (#257v6ck).

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -63,7 +63,10 @@ const actions: ActionTree<UserState, RootState> = {
         "noConditionFind": "Y"
       }
 
-      await dispatch('getEComStores', payload).then((stores: any) => {
+      let stores = await UserService.getEComStores(payload);
+      if(stores.status === 200 && stores.data.docs?.length > 0 && !hasError(stores)) {
+        stores = stores.data.docs;
+
         resp.data.stores = [
           ...(stores ? stores : []),
           {
@@ -71,8 +74,7 @@ const actions: ActionTree<UserState, RootState> = {
             storeName: "None"
           }
         ]
-      })
-
+      }
       this.dispatch('util/getServiceStatusDesc')
 
       commit(types.USER_CURRENT_ECOM_STORE_UPDATED, resp.data?.stores[0]);
@@ -115,21 +117,6 @@ const actions: ActionTree<UserState, RootState> = {
 
     if (resp.status === 200 && !hasError(resp)) {
       commit(types.USER_SHOPIFY_CONFIG_UPDATED, resp.data.docs?.length > 0 ? resp.data.docs[0].shopifyConfigId : {});
-    }
-  },
-
-  async getEComStores(_context, payload) {
-    let resp;
-
-    try{
-      resp = await UserService.getEComStores(payload);
-      if (resp.status === 200 && resp.data.docs?.length > 0 && !hasError(resp)) {
-        const stores = resp.data.docs
-
-        return stores
-      }
-    } catch(err) {
-      console.error(err)
     }
   },
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
:- Worked on reverting the ```getEcomStores``` action and fetching all stores in getProfile action.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
https://user-images.githubusercontent.com/52008359/169795221-a0f2e3ef-22aa-47ba-ab1f-b25e8c4e76b4.mp4



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)