### PR TITLE
Fixed: Show the correct job information when clicking on an already scheduled batch job(#2d99ucd)

### DIFF
--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -26,10 +26,12 @@
     <ion-radio-group>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('New orders') }}</ion-label>
+        <!-- "this.currentScheduledBatch?.unfillable === false" - Did this because ion-radio is not considering boolean -->
         <ion-radio :checked="this.currentScheduledBatch?.unfillable === false" slot="start" @click="unfillableOrder = false" color="secondary"/>
       </ion-item>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('Unfillable orders') }}</ion-label>
+        <!-- "this.currentScheduledBatch?.unfillable === false" - Did this because ion-radio is not considering boolean -->
         <ion-radio :checked="this.currentScheduledBatch?.unfillable === true" slot="start" @click="unfillableOrder = true" color="secondary"/>
       </ion-item>
     </ion-radio-group>
@@ -98,11 +100,12 @@ export default defineComponent({
       jobEnums: JSON.parse(process.env?.VUE_APP_BATCH_JOB_ENUMS as string) as any,
       currentBatch: {} as any,
       jobName: '' as string,
-      unfillableOrder: false as boolean,
+      unfillableOrder: 'false',
       batchFacilityId: '_NA_' as string,
       currentDateTime: '' as string,
       jobRunTime: '' as any,
-      currentScheduledBatch: {} as object 
+      currentScheduledBatch: {} as any,
+      orders: ""
     }
   },
   computed: {
@@ -111,7 +114,7 @@ export default defineComponent({
       shopifyConfigId: 'user/getShopifyConfigId',
       currentEComStore: 'user/getCurrentEComStore',
       userProfile: "user/getUserProfile"
-    })
+    }),
   },
   mounted() {
     this.getCurrentBatch();

--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -17,7 +17,7 @@
     </ion-item>
     <ion-item :disabled="currentBatch?.jobId">
       <ion-label>{{ $t('Order queue') }}</ion-label>
-      <ion-select slot="end" interface="popover" :value="this.currentScheduledBatch?.facilityId || batchFacilityId" @ionChange="updateFacilityId($event)">
+      <ion-select slot="end" interface="popover" :value="this.currentScheduledBatch?.facilityId || batchFacilityId" @ionChange="batchFacilityId = $event['detail'].value">
         <ion-select-option value="_NA_">{{ $t("Brokering queue") }}</ion-select-option>
         <ion-select-option value="PRE_ORDER_PARKING">{{ $t("Pre-order parking") }}</ion-select-option>
         <ion-select-option value="BACKORDER_PARKING">{{ $t("Back-order parking") }}</ion-select-option>
@@ -120,9 +120,6 @@ export default defineComponent({
     this.getCurrentBatch();
   },
   methods: {
-    updateFacilityId(ev: CustomEvent) {
-      this.batchFacilityId = ev['detail'].value
-    },
     getCurrentBatch() {
       this.currentBatch = this.getJob(this.enumId)?.find((job: any) => job.id === this.id)
       this.jobName = this.currentBatch?.jobName;

--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -18,7 +18,7 @@
 
     <ion-item :disabled="currentBatch?.jobId">
       <ion-label>{{ $t('Order queue') }}</ion-label>
-      <ion-select slot="end" interface="popover" v-model="batchFacilityId">
+      <ion-select slot="end" interface="popover" :value="this.currentScheduledBatch?.facilityId || batchFacilityId">
         <ion-select-option value="_NA_">{{ $t("Brokering queue") }}</ion-select-option>
         <ion-select-option value="PRE_ORDER_PARKING">{{ $t("Pre-order parking") }}</ion-select-option>
         <ion-select-option value="BACKORDER_PARKING">{{ $t("Back-order parking") }}</ion-select-option>
@@ -27,11 +27,11 @@
     <ion-radio-group>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('New orders') }}</ion-label>
-        <ion-radio :checked="this.currentBatchDetail?.unfillable === false" slot="start" @click="unfillableOrder = false" color="secondary"/>
+        <ion-radio :checked="this.currentScheduledBatch?.unfillable === false" slot="start" @click="unfillableOrder = false" color="secondary"/>
       </ion-item>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('Unfillable orders') }}</ion-label>
-        <ion-radio :checked="this.currentBatchDetail?.unfillable === true" slot="start" @click="unfillableOrder = true" color="secondary"/>
+        <ion-radio :checked="this.currentScheduledBatch?.unfillable === true" slot="start" @click="unfillableOrder = true" color="secondary"/>
       </ion-item>
     </ion-radio-group>
     
@@ -104,7 +104,7 @@ export default defineComponent({
       batchFacilityId: '_NA_' as string,
       currentDateTime: '' as string,
       jobRunTime: '' as any,
-      currentBatchDetail: {} as object 
+      currentScheduledBatch: {} as object 
     }
   },
   computed: {
@@ -122,9 +122,7 @@ export default defineComponent({
     getCurrentBatch() {
       this.currentBatch = this.getJob(this.enumId)?.find((job: any) => job.id === this.id)
       this.jobName = this.currentBatch?.jobName;
-      this.currentBatchDetail = (this as any).jobEnums[this.currentBatch?.enumId];
-      console.log(this.currentBatchDetail);
-      
+      this.currentScheduledBatch = (this as any).jobEnums[this.currentBatch?.enumId];
     },
     getDateTime(time: any) {
       return DateTime.fromMillis(time)

--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -15,10 +15,9 @@
       <ion-label position="fixed">{{ $t('Batch name') }}</ion-label>
       <ion-input :placeholder="currentDateTime = getCurrentDateTime()" v-model="jobName" />
     </ion-item>
-
     <ion-item :disabled="currentBatch?.jobId">
       <ion-label>{{ $t('Order queue') }}</ion-label>
-      <ion-select slot="end" interface="popover" :value="this.currentScheduledBatch?.facilityId || batchFacilityId">
+      <ion-select slot="end" interface="popover" :value="this.currentScheduledBatch?.facilityId || batchFacilityId" @ionChange="updateFacilityId($event)">
         <ion-select-option value="_NA_">{{ $t("Brokering queue") }}</ion-select-option>
         <ion-select-option value="PRE_ORDER_PARKING">{{ $t("Pre-order parking") }}</ion-select-option>
         <ion-select-option value="BACKORDER_PARKING">{{ $t("Back-order parking") }}</ion-select-option>
@@ -34,7 +33,6 @@
         <ion-radio :checked="this.currentScheduledBatch?.unfillable === true" slot="start" @click="unfillableOrder = true" color="secondary"/>
       </ion-item>
     </ion-radio-group>
-    
     <ion-item>
       <ion-label position="fixed">{{ $t("Schedule") }}</ion-label>
       <ion-datetime :value="currentBatch?.runTime ? getDateTime(currentBatch.runTime) : ''" @ionChange="updateRunTime($event)" presentation="time" size="cover" />
@@ -119,6 +117,9 @@ export default defineComponent({
     this.getCurrentBatch();
   },
   methods: {
+    updateFacilityId(ev: CustomEvent) {
+      this.batchFacilityId = ev['detail'].value
+    },
     getCurrentBatch() {
       this.currentBatch = this.getJob(this.enumId)?.find((job: any) => job.id === this.id)
       this.jobName = this.currentBatch?.jobName;
@@ -132,14 +133,13 @@ export default defineComponent({
     },
     async updateJob() {
       let batchJobEnum = this.enumId;
-    
       if (!batchJobEnum) {
-        const jobEnum: any = Object.values(this.jobEnums)?.find((job: any) => { 
+        const jobEnum: any = Object.values(this.jobEnums)?.find((job: any) => {
           return job.unfillable === this.unfillableOrder && job.facilityId === this.batchFacilityId
         });
         batchJobEnum = jobEnum.id
       }
-      
+
       const job = this.currentBatch ? this.currentBatch : this.getJob(batchJobEnum)?.find((job: any) => job.status === 'SERVICE_DRAFT');
 
       if (!job) {

--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -15,6 +15,7 @@
       <ion-label position="fixed">{{ $t('Batch name') }}</ion-label>
       <ion-input :placeholder="currentDateTime = getCurrentDateTime()" v-model="jobName" />
     </ion-item>
+
     <ion-item :disabled="currentBatch?.jobId">
       <ion-label>{{ $t('Order queue') }}</ion-label>
       <ion-select slot="end" interface="popover" v-model="batchFacilityId">
@@ -23,14 +24,14 @@
         <ion-select-option value="BACKORDER_PARKING">{{ $t("Back-order parking") }}</ion-select-option>
       </ion-select>
     </ion-item>
-    <ion-radio-group value="unfillableOrder">
+    <ion-radio-group>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('New orders') }}</ion-label>
-        <ion-radio slot="start" @click="unfillableOrder = false" color="secondary" value="unfillableOrder" />
+        <ion-radio :checked="this.currentBatchDetail?.unfillable === false" slot="start" @click="unfillableOrder = false" color="secondary"/>
       </ion-item>
       <ion-item :disabled="currentBatch?.jobId">
         <ion-label>{{ $t('Unfillable orders') }}</ion-label>
-        <ion-radio slot="start" @click="unfillableOrder = true" color="secondary"/>
+        <ion-radio :checked="this.currentBatchDetail?.unfillable === true" slot="start" @click="unfillableOrder = true" color="secondary"/>
       </ion-item>
     </ion-radio-group>
     
@@ -102,7 +103,8 @@ export default defineComponent({
       unfillableOrder: false as boolean,
       batchFacilityId: '_NA_' as string,
       currentDateTime: '' as string,
-      jobRunTime: '' as any
+      jobRunTime: '' as any,
+      currentBatchDetail: {} as object 
     }
   },
   computed: {
@@ -119,7 +121,10 @@ export default defineComponent({
   methods: {
     getCurrentBatch() {
       this.currentBatch = this.getJob(this.enumId)?.find((job: any) => job.id === this.id)
-      this.jobName = this.currentBatch?.jobName
+      this.jobName = this.currentBatch?.jobName;
+      this.currentBatchDetail = (this as any).jobEnums[this.currentBatch?.enumId];
+      console.log(this.currentBatchDetail);
+      
     },
     getDateTime(time: any) {
       return DateTime.fromMillis(time)
@@ -129,14 +134,14 @@ export default defineComponent({
     },
     async updateJob() {
       let batchJobEnum = this.enumId;
-      
+    
       if (!batchJobEnum) {
         const jobEnum: any = Object.values(this.jobEnums)?.find((job: any) => { 
           return job.unfillable === this.unfillableOrder && job.facilityId === this.batchFacilityId
         });
         batchJobEnum = jobEnum.id
       }
-
+      
       const job = this.currentBatch ? this.currentBatch : this.getJob(batchJobEnum)?.find((job: any) => job.status === 'SERVICE_DRAFT');
 
       if (!job) {

--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -100,7 +100,7 @@ export default defineComponent({
       jobEnums: JSON.parse(process.env?.VUE_APP_BATCH_JOB_ENUMS as string) as any,
       currentBatch: {} as any,
       jobName: '' as string,
-      unfillableOrder: 'false',
+      unfillableOrder: false as boolean,
       batchFacilityId: '_NA_' as string,
       currentDateTime: '' as string,
       jobRunTime: '' as any,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#2d99ucd

Closes #
https://github.com/hotwax/job-manager/commit/a8598746dc8b744d87af39d22d21a2f0eda176b2

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now user can see correct information of scheduled job.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/62360781/170114112-5eb9d71b-2888-45b2-a22f-dd10d4fc7381.mov


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)