### PR TITLE
Fixed: issue of configuration component taking space in DOM but data not being displayed when coming back to pipeline page

### DIFF
--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -561,10 +561,14 @@ export default defineComponent({
       }
     }
   },
-  created() {
+  async created() {
     this.getPendingJobs();
     this.store.dispatch('user/getPinnedJobs');
     emitter.on('jobUpdated', this.updateJobs);
+    // TODO: improved this to manage the current job using local variable
+    // setting the current job as empty because when coming back to the pipeline page the currentJob
+    // state does not gets updated and hence the job configuration component takes it space in DOM
+    await this.store.dispatch('job/updateCurrentJob', { job: {} });
   },
   mounted(){
     emitter.on("pinnedJobsUpdated", (this as any).updateSelectedPinnedJob);


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:
JobConfiguration component present in DOM when coming back from any other page to pipeline page

![image](https://user-images.githubusercontent.com/41404838/170273672-938a7eb5-e661-4f2a-a4b5-9bd09109d040.png)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)