### PR TITLE
Fixed: After refreshing and then clicking the back button the user is  redirected to the pipeline page(job-manager(#2deygnv)

### DIFF
--- a/src/views/JobDetails.vue
+++ b/src/views/JobDetails.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button default-href="/" slot="start" />
+        <ion-back-button :default-href="'/' + jobCategory" slot="start" />
         <ion-title>{{ $t("Job details") }}</ion-title>
       </ion-toolbar>
     </ion-header>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#2deygnv

Closes #
https://github.com/hotwax/job-manager/commit/569e768ba134098c2bf7523ea18b88981a1c8bd6

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
(On mobile view) - Now when user navigates back even on refresh, He/She lands on correct page i.e page, He/She came from not the home page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
#### Before

https://user-images.githubusercontent.com/62360781/170435712-d6fba750-f0cd-42de-9e19-125fed7e025a.mov

#### After

https://user-images.githubusercontent.com/62360781/170436365-0595a383-17d2-4259-9184-669b413b687c.mov



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)