### PR TITLE
Fixed: issue of auto cancel job check is not reflected on UI when the job is scheduled(#28u4g5n)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -214,7 +214,7 @@ export default defineComponent({
       return status && status !== "SERVICE_DRAFT";
     },
     autoCancelCheckDaily(): boolean {
-      const status = this.getJobStatus(this.jobEnums["REAL_WBHKS"]);
+      const status = this.getJobStatus(this.jobEnums["AUTO_CNCL_DAL"]);
       return status && status !== "SERVICE_DRAFT";
     },
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
The button for auto cancel order daily is not checked even when the job is scheduled.

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
The issue is due to the wrong enum being mapped to the toggle button, so added the correct enum mapping.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)