### PR TITLE
Improved: runTime set to start of the day for 'EVERYDAY' frequency else current time (#2ftb2vw)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -133,7 +133,7 @@ const handleDateTimeInput = (dateTimeValue: any) => {
 
 const prepareRuntime = (job: any) => {
   if (job.frequency === 'EVERYDAY') {
-    return DateTime.local().startOf('day').toMillis()
+    return DateTime.now().startOf('day').toMillis()
   } else {
     return DateTime.now().toMillis()
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -131,9 +131,12 @@ const handleDateTimeInput = (dateTimeValue: any) => {
   return DateTime.fromISO(dateTime).toMillis()
 }
 
-const updateRuntime = (job: any) => {
-  job?.frequency === 'EVERYDAY' ? job.runTime = DateTime.local().startOf('day').toMillis(): job.runTime =  DateTime.now().toMillis()
-  return job.runTime;
+const prepareRuntime = (job: any) => {
+  if (job.frequency === 'EVERYDAY') {
+    return DateTime.local().startOf('day').toMillis()
+  } else {
+    return DateTime.now().toMillis()
+  }
 }
 
-export { handleDateTimeInput, showToast, hasError , parseCsv , jsonToCsv, JsonToCsvOption, isFutureDate, updateRuntime }
+export { handleDateTimeInput, showToast, hasError , parseCsv , jsonToCsv, JsonToCsvOption, isFutureDate, prepareRuntime }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -131,4 +131,9 @@ const handleDateTimeInput = (dateTimeValue: any) => {
   return DateTime.fromISO(dateTime).toMillis()
 }
 
-export { handleDateTimeInput, showToast, hasError , parseCsv , jsonToCsv, JsonToCsvOption, isFutureDate }
+const updateRuntime = (job: any) => {
+  job?.frequency === 'EVERYDAY' ? job.runTime = DateTime.local().startOf('day').toMillis(): job.runTime =  DateTime.now().toMillis()
+  return job.runTime;
+}
+
+export { handleDateTimeInput, showToast, hasError , parseCsv , jsonToCsv, JsonToCsvOption, isFutureDate, updateRuntime }

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -62,7 +62,7 @@ import {
 import { defineComponent } from 'vue';
 import { mapGetters, useStore } from 'vuex';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate } from '@/utils';
+import { isFutureDate, updateRuntime } from '@/utils';
 import emitter from '@/event-bus';
 import { useRouter } from 'vue-router'
 
@@ -128,6 +128,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
+        job.runTime = updateRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -62,7 +62,7 @@ import {
 import { defineComponent } from 'vue';
 import { mapGetters, useStore } from 'vuex';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate, updateRuntime } from '@/utils';
+import { isFutureDate, prepareRuntime } from '@/utils';
 import emitter from '@/event-bus';
 import { useRouter } from 'vue-router'
 
@@ -128,7 +128,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
-        job.runTime = updateRuntime(job)
+        job.runTime = prepareRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -159,7 +159,7 @@ import { useRouter } from 'vue-router'
 import { mapGetters } from "vuex";
 import JobConfiguration from '@/components/JobConfiguration.vue';
 import { DateTime } from 'luxon';
-import { hasError, isFutureDate, showToast } from '@/utils';
+import { hasError, isFutureDate, showToast, updateRuntime } from '@/utils';
 import emitter from '@/event-bus';
 
 export default defineComponent({
@@ -300,6 +300,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
+        job.runTime = updateRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -159,7 +159,7 @@ import { useRouter } from 'vue-router'
 import { mapGetters } from "vuex";
 import JobConfiguration from '@/components/JobConfiguration.vue';
 import { DateTime } from 'luxon';
-import { hasError, isFutureDate, showToast, updateRuntime } from '@/utils';
+import { hasError, isFutureDate, showToast, prepareRuntime } from '@/utils';
 import emitter from '@/event-bus';
 
 export default defineComponent({
@@ -300,7 +300,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
-        job.runTime = updateRuntime(job)
+        job.runTime = prepareRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)

--- a/src/views/PreOrder.vue
+++ b/src/views/PreOrder.vue
@@ -134,7 +134,7 @@ import { mapGetters } from "vuex";
 import { useRouter } from 'vue-router'
 import { alertController } from '@ionic/vue';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate, updateRuntime } from '@/utils';
+import { isFutureDate, prepareRuntime } from '@/utils';
 import emitter from '@/event-bus';
 
 export default defineComponent({
@@ -240,7 +240,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
-        job.runTime = updateRuntime(job)
+        job.runTime = prepareRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)

--- a/src/views/PreOrder.vue
+++ b/src/views/PreOrder.vue
@@ -134,7 +134,7 @@ import { mapGetters } from "vuex";
 import { useRouter } from 'vue-router'
 import { alertController } from '@ionic/vue';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate } from '@/utils';
+import { isFutureDate, updateRuntime } from '@/utils';
 import emitter from '@/event-bus';
 
 export default defineComponent({
@@ -240,6 +240,7 @@ export default defineComponent({
       if (!checked) {
         this.store.dispatch('job/cancelJob', job)
       } else if (job?.status === 'SERVICE_DRAFT') {
+        job.runTime = updateRuntime(job)
         this.store.dispatch('job/scheduleService', job)
       } else if (job?.status === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)


### PR DESCRIPTION
### Related Issues

Closes #

### Short Description and Why It's Useful
Implemented: update runtime method to set the start of the day & current time according to job frequency
If job frequency is 'EVERYDAY' it will set start of the day else current time

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x]  I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)