### PR TITLE
Fixed: the issue of null value being passed in payload when scheduling a job(#2hjh89u)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -426,6 +426,11 @@ const actions: ActionTree<JobState, RootState> = {
     job?.priority && (payload['SERVICE_PRIORITY'] = job.priority.toString())
     job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
 
+    // assigning '' (empty string) to all the runtimeData properties whose value is "null"
+    Object.keys(job.runtimeData).map((key: any) => {
+      if (job.runtimeData[key] === 'null' ) job.runtimeData[key] = ''
+    })
+
     try {
       resp = await JobService.scheduleJob({ ...job.runtimeData, ...payload });
       if (resp.status == 200 && !hasError(resp)) {
@@ -540,6 +545,11 @@ const actions: ActionTree<JobState, RootState> = {
     job?.priority && (payload['SERVICE_PRIORITY'] = job.priority.toString())
     job?.sinceId && (payload['sinceId'] = job.sinceId)
     job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
+
+    // assigning '' (empty string) to all the runtimeData properties whose value is "null"
+    Object.keys(job.runtimeData).map((key: any) => {
+      if (job.runtimeData[key] === 'null' ) job.runtimeData[key] = ''
+    })
 
     try {
       resp = await JobService.scheduleJob({ ...job.runtimeData, ...payload });

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -427,7 +427,7 @@ const actions: ActionTree<JobState, RootState> = {
     job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
 
     // assigning '' (empty string) to all the runtimeData properties whose value is "null"
-    Object.keys(job.runtimeData).map((key: any) => {
+    job.runtimeData && Object.keys(job.runtimeData).map((key: any) => {
       if (job.runtimeData[key] === 'null' ) job.runtimeData[key] = ''
     })
 
@@ -547,7 +547,7 @@ const actions: ActionTree<JobState, RootState> = {
     job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
 
     // assigning '' (empty string) to all the runtimeData properties whose value is "null"
-    Object.keys(job.runtimeData).map((key: any) => {
+    job.runtimeData && Object.keys(job.runtimeData).map((key: any) => {
       if (job.runtimeData[key] === 'null' ) job.runtimeData[key] = ''
     })
 


### PR DESCRIPTION
### Related Issues
When scheduling a job, then in runtimeData we are getting some values as "null", and when passed it results in an error on the server.

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a check when scheduling a service to assign empty string to those properties in runtimeData whose value is "null".


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)