### PR TITLE
Implemented: code to display a toast when the job is not present (#2fyy5bd)

### DIFF
--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -62,9 +62,10 @@ import {
 import { defineComponent } from 'vue';
 import { mapGetters, useStore } from 'vuex';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate, prepareRuntime } from '@/utils';
+import { isFutureDate, prepareRuntime, showToast } from '@/utils';
 import emitter from '@/event-bus';
 import { useRouter } from 'vue-router'
+import { translate } from '@/i18n';
 
 export default defineComponent({
   name: 'Inventory',
@@ -111,6 +112,12 @@ export default defineComponent({
   methods: {
     async updateJob(checked: boolean, id: string, status="EVERY_15_MIN") {
       const job = this.getJob(id);
+
+      // added check that if the job is not present, then display a toast and then return
+      if (!job) {
+        showToast(translate('Configuration missing'))
+        return;
+      }
 
       // TODO: added this condition to not call the api when the value of the select automatically changes
       // need to handle this properly

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -339,6 +339,12 @@ export default defineComponent({
     async updateJob(checked: boolean, id: string, status = 'EVERY_15_MIN') {
       const job = this.getJob(id);
 
+      // added check that if the job is not present, then display a toast and then return
+      if (!job) {
+        showToast(translate('Configuration missing'))
+        return;
+      }
+
       // TODO: added this condition to not call the api when the value of the select automatically changes
       // need to handle this properly
       if (!job || (checked && job?.status === 'SERVICE_PENDING') || (!checked && job?.status === 'SERVICE_DRAFT')) {

--- a/src/views/PreOrder.vue
+++ b/src/views/PreOrder.vue
@@ -142,8 +142,9 @@ import { mapGetters } from "vuex";
 import { useRouter } from 'vue-router'
 import { alertController } from '@ionic/vue';
 import JobConfiguration from '@/components/JobConfiguration.vue'
-import { isFutureDate, prepareRuntime } from '@/utils';
+import { isFutureDate, prepareRuntime, showToast } from '@/utils';
 import emitter from '@/event-bus';
+import { translate } from '@/i18n';
 
 export default defineComponent({
   name: 'PreOrder',
@@ -239,6 +240,12 @@ export default defineComponent({
   methods: {
     async updateJob(checked: boolean, id: string, status = 'EVERY_15_MIN') {
       const job = this.getJob(id);
+
+      // added check that if the job is not present, then display a toast and then return
+      if (!job) {
+        showToast(translate('Configuration missing'))
+        return;
+      }
 
       // TODO: added this condition to not call the api when the value of the select automatically changes
       // need to handle this properly


### PR DESCRIPTION
it displayed a toast 'Configuration missing' before returning.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Handled the case when the job is not present, it displayed a toast Configuration missing before returning.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/33576503/179979640-9aaf71f1-8800-4d69-b598-222489d825b7.mp4



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)