### PR TITLE
Fixed: Orders are not imported with multiple shopify configuration(#2mky5yp)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -398,7 +398,7 @@ const actions: ActionTree<JobState, RootState> = {
     return resp;
   },
 
-  async scheduleService({ dispatch, commit, rootGetters }, job) {
+  async scheduleService({ dispatch, commit }, job) {
     let resp;
 
     const payload = {
@@ -416,7 +416,7 @@ const actions: ActionTree<JobState, RootState> = {
         'runAsUser': 'system', //default system, but empty in run now.  TODO Need to remove this as we are using SERVICE_RUN_AS_SYSTEM, currently kept it for backward compatibility
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': rootGetters['user/getShopifyConfigId'],
+      'shopifyConfigId': this.state.user.shopifyConfig,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -520,7 +520,7 @@ const actions: ActionTree<JobState, RootState> = {
     return resp;
   },
 
-  async runServiceNow({ dispatch, rootGetters }, job) {
+  async runServiceNow({ dispatch }, job) {
     let resp;
 
     const payload = {
@@ -535,7 +535,7 @@ const actions: ActionTree<JobState, RootState> = {
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': rootGetters['user/getShopifyConfigId'],
+      'shopifyConfigId': this.state.user.shopifyConfig,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -416,7 +416,7 @@ const actions: ActionTree<JobState, RootState> = {
         'runAsUser': 'system', //default system, but empty in run now.  TODO Need to remove this as we are using SERVICE_RUN_AS_SYSTEM, currently kept it for backward compatibility
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': this.state.user.shopifyConfig,
+      'shopifyConfigId': this.state.user.shopifyConfigId,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any
@@ -535,7 +535,7 @@ const actions: ActionTree<JobState, RootState> = {
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': this.state.user.shopifyConfig,
+      'shopifyConfigId': this.state.user.shopifyConfigId,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -8,7 +8,7 @@ import { translate } from '@/i18n'
 
 const actions: ActionTree<WebhookState, RootState> = {
   async fetchWebhooks({ commit }) {
-    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.shopifyConfig }).then(resp => {
+    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.shopifyConfigId }).then(resp => {
       if (resp.status == 200 && resp.data.webhooks?.length > 0 && !hasError(resp)) {
         const webhooks = resp.data.webhooks;
         const topics: any = {}
@@ -58,7 +58,7 @@ const actions: ActionTree<WebhookState, RootState> = {
     let resp;
 
     try {
-      resp = await webhookMethod({ shopifyConfigId: this.state.user.shopifyConfig })
+      resp = await webhookMethod({ shopifyConfigId: this.state.user.shopifyConfigId })
 
       if (resp.status == 200 && !hasError(resp)) {
         showToast(translate('Webhook subscribed successfully'))

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -7,8 +7,8 @@ import * as types from './mutations-types'
 import { translate } from '@/i18n'
 
 const actions: ActionTree<WebhookState, RootState> = {
-  async fetchWebhooks({ commit, rootGetters }) {
-    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: rootGetters['user/getShopifyConfigId'] }).then(resp => {
+  async fetchWebhooks({ commit }) {
+    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.shopifyConfig }).then(resp => {
       if (resp.status == 200 && resp.data.webhooks?.length > 0 && !hasError(resp)) {
         const webhooks = resp.data.webhooks;
         const topics: any = {}
@@ -35,7 +35,7 @@ const actions: ActionTree<WebhookState, RootState> = {
       dispatch('fetchWebhooks')
     }
   },
-  async subscribeWebhook({ dispatch, rootGetters }, id: string) {
+  async subscribeWebhook({ dispatch }, id: string) {
 
     // stores the webhook service that needs to be called on the basis of current webhook selected, doing
     // so as we have defined separate service for different webhook subscription
@@ -58,7 +58,7 @@ const actions: ActionTree<WebhookState, RootState> = {
     let resp;
 
     try {
-      resp = await webhookMethod({ shopifyConfigId: rootGetters['user/getShopifyConfigId'] })
+      resp = await webhookMethod({ shopifyConfigId: this.state.user.shopifyConfig })
 
       if (resp.status == 200 && !hasError(resp)) {
         showToast(translate('Webhook subscribed successfully'))


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed: Orders are not imported with multiple Shopify configuration

When changing the product store or scheduling any job, by accessing the state (this.state.user.**shopifyConfig**) the updated Shopify config Id is not accessed.
Now the state will be accessed by rootGetters (this.state.user.**shopifyConfigId**)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/33576503/181268370-a0245765-9815-41a7-9d80-a0520be5d7b5.mp4


https://user-images.githubusercontent.com/33576503/181268413-d185b843-07dd-4f90-951e-d48cdd6c6917.mp4



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)