### PR TITLE
Fixed: the issue of service time being passed when using run now functionality for pending jobs(#2r0jq44)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -531,7 +531,7 @@ const actions: ActionTree<JobState, RootState> = {
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': job.status === "SERIVCE_PENDING" ? job.shopifyConfigId : this.state.user.currentShopifyConfigId,
+      'shopifyConfigId': job.status === "SERVICE_PENDING" ? job.shopifyConfigId : this.state.user.currentShopifyConfigId,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any
@@ -540,7 +540,7 @@ const actions: ActionTree<JobState, RootState> = {
     job?.runtimeData?.productStoreId?.length >= 0 && (payload['productStoreId'] = job.status === "SERVICE_PENDING" ? job.productStoreId : this.state.user.currentEComStore.productStoreId)
     job?.priority && (payload['SERVICE_PRIORITY'] = job.priority.toString())
     job?.sinceId && (payload['sinceId'] = job.sinceId)
-    job?.runTime && (payload['SERVICE_TIME'] = job.runTime.toString())
+    job?.runTime && job.status !== "SERVICE_PENDING" && (payload['SERVICE_TIME'] = job.runTime.toString())
 
     // assigning '' (empty string) to all the runtimeData properties whose value is "null"
     job.runtimeData && Object.keys(job.runtimeData).map((key: any) => {


### PR DESCRIPTION
### Related Issues
When using run now functionality on a pending job, then the runTime for the pending job gets passed to the run now job.

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a check to not pass runTime when the job is of pending status when using run now functionality.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)