### PR TITLE
Fixed: missing productStoreId and shopifyConfigId for Job while using runNow (#2r0jq44)

### DIFF
--- a/src/components/JobActionsPopover.vue
+++ b/src/components/JobActionsPopover.vue
@@ -110,6 +110,7 @@ export default defineComponent({
               handler: async () => {
                 if(job) {
                   await this.store.dispatch('job/runServiceNow', job)
+                  this.closePopover();
                 }
               }
             }

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -187,7 +187,7 @@ const actions: ActionTree<JobState, RootState> = {
         "statusId": "SERVICE_PENDING",
         "systemJobEnumId_op": "not-empty"
       } as any,
-      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "currentRetryCount", "statusId", "productStoreId" ],
+      "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "currentRetryCount", "statusId", "productStoreId", "runtimeDataId" ],
       "noConditionFind": "Y",
       "viewSize": payload.viewSize,
       "viewIndex": payload.viewIndex,
@@ -531,7 +531,7 @@ const actions: ActionTree<JobState, RootState> = {
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone
       },
-      'shopifyConfigId': job.status === "SERVICE_PENDING" ? job.shopifyConfigId : this.state.user.currentShopifyConfigId,
+      'shopifyConfigId': job.status === "SERVICE_PENDING" ? job.runtimeData?.shopifyConfigId : this.state.user.currentShopifyConfigId,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any


### PR DESCRIPTION
While fetching the Job, runtimeDataId was missing in fieldList due which runtime data was never fetched
Additonal change:
Close popover when the action is complete

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)