### PR TITLE
Fixed: Run now functionality for the job manager is not working correctly (#2rhqqf7)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -81,7 +81,7 @@ const actions: ActionTree<JobState, RootState> = {
           const total = resp.data.count;
           let jobs = resp.data.docs;
           if(payload.viewIndex && payload.viewIndex > 0){
-            jobs = state.history.list.concat(resp.data.docs);
+            jobs = state.history.list.concat(jobs);
           }
           jobs.map((job: any) => {
             job['statusDesc'] = this.state.util.statusDesc[job.statusId];
@@ -155,7 +155,7 @@ const actions: ActionTree<JobState, RootState> = {
           const total = resp.data.count;
           let jobs = resp.data.docs;
           if(payload.viewIndex && payload.viewIndex > 0){
-            jobs = state.running.list.concat(resp.data.docs);
+            jobs = state.running.list.concat(jobs);
           }
           jobs.map((job: any) => {
             job['statusDesc'] = this.state.util.statusDesc[job.statusId];
@@ -226,7 +226,7 @@ const actions: ActionTree<JobState, RootState> = {
             }
           })
           if(payload.viewIndex && payload.viewIndex > 0){
-            jobs = state.pending.list.concat(resp.data.docs);
+            jobs = state.pending.list.concat(jobs);
           }
           commit(types.JOB_PENDING_UPDATED, { jobs, total });
           const tempExprList = [] as any;


### PR DESCRIPTION


SERVICE_TIME is passed for the jobs that are fetched with infinite scroll
While concatenating the new jobs fetched with infinite scroll the response is passed instead of the jobs variable modified as per the app schema.
status field which is populated in jobs is missing in response, thus when calling run service now as the status is undefined service time is passed as is

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)