### PR TITLE
Fixed: Not able to open job update section on Pipeline page for some jobs (#2rht6hk)

### DIFF
--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -153,6 +153,11 @@ export default defineComponent({
       minDateTime: DateTime.now().toISO()
     }
   },
+  updated() {
+    // When updating the job, the job is fetched again with the latest values
+    // Updated value should be set to instance variable jobStatus
+    this.jobStatus = this.currentJob.statusId === "SERVICE_DRAFT" ? this.currentJob.statusId : this.currentJob.tempExprId;
+  },
   props: ["title", "status", "type"],
   computed: {
     ...mapGetters({

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -530,7 +530,8 @@ export default defineComponent({
       this.title = this.getEnumName(job.systemJobEnumId)
       this.currentJobStatus = job.tempExprId
       const id = Object.entries(this.jobEnums).find((enums) => enums[1] == job.systemJobEnumId) as any
-      this.freqType = id && (Object.entries(this.jobFrequencyType).find((freq) => freq[0] == id[0]) as any)[1]
+      const appFreqType =  id && (Object.entries(this.jobFrequencyType).find((freq) => freq[0] == id[0]) as any)
+      this.freqType = appFreqType ? appFreqType[1] : "default"
 
       await this.store.dispatch('job/updateCurrentJob', { job });
       if(!this.isDesktop && job?.jobId) {


### PR DESCRIPTION
Handled case when freq type is not available in environment file. Set default freq type if doesn't exist .env

Additional fixes:
Missing description when navigating from pipeline to Job Configuration. description field missing in field list while fetching pending jobs
When updating the frequency it is not reflecting on Job Configuration component, current is updated but jobStatus is not updated. Used updated lifecycle hook to reintialise the value
When skip or cancel job is done for pending jobs, UI flicker occurs. Current is updated whenever skip/cancel action is performed. It should be done only when JobConfiguration component is open and current has some value. Added check to check current before fetching and updating the job.
Removed some redundant code

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://app.clickup.com/t/2rht6hk

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)