### PR TITLE
Fixed: shop should be honored while fetching jobs (#2te9p7v)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -44,7 +44,12 @@ const actions: ActionTree<JobState, RootState> = {
       "inputFields": {
         "statusId": ["SERVICE_CANCELLED", "SERVICE_CRASHED", "SERVICE_FAILED", "SERVICE_FINISHED"],
         "statusId_op": "in",
-        "systemJobEnumId_op": "not-empty"
+        "systemJobEnumId_op": "not-empty",
+        "shopId_fld0_value": store.state.user.currentShopifyConfig?.shopId,
+        "shopId_fld0_grp": "1",
+        "shopId_fld0_op": "equals",
+        "shopId_fld1_grp": "2",
+        "shopId_fld1_op": "empty"
       } as any,
       "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId", "cancelDateTime", "finishDateTime", "startDateTime" ],
       "noConditionFind": "Y",
@@ -113,12 +118,13 @@ const actions: ActionTree<JobState, RootState> = {
     const params = {
       "inputFields": {
         "systemJobEnumId_op": "not-empty",
-        "statusId_fld0_value": "SERVICE_RUNNING",
-        "statusId_fld0_op": "equals",
-        "statusId_fld0_grp": "1",
-        "statusId_fld1_value": "SERVICE_QUEUED",
-        "statusId_fld1_op": "equals",
-        "statusId_fld1_grp": "2",
+        "statusId": ["SERVICE_RUNNING", "SERVICE_QUEUED"],
+        "statusId_op": "in",
+        "shopId_fld0_value": store.state.user.currentShopifyConfig?.shopId,
+        "shopId_fld0_grp": "1",
+        "shopId_fld0_op": "equals",
+        "shopId_fld1_grp": "2",
+        "shopId_fld1_op": "empty"
       } as any,
       "fieldList": [ "systemJobEnumId", "runTime", "tempExprId", "parentJobId", "serviceName", "jobId", "jobName", "statusId" ],
       "noConditionFind": "Y",
@@ -337,17 +343,22 @@ const actions: ActionTree<JobState, RootState> = {
   },
   
   async fetchJobs ({ state, commit, dispatch }, payload) {
-    const params = {
+    // We are fetching the draft and pending jobs separately as we could only have single OR condition in query
+    // Earlier we were having ORing on status only, but now we want to add condition for shopId as well
+    // Instead of complicating the query, we have made 2 separate call with status conditions and merged them
+
+
+    // Fetching the draft jobs first
+    const fetchJobRequests = [];
+    let params = {
       "inputFields": {
-        "statusId_fld0_value": "SERVICE_DRAFT",
-        "statusId_fld0_op": "equals",
-        "statusId_fld0_grp": "1",
-        "statusId_fld1_value": "SERVICE_PENDING",
-        "statusId_fld1_op": "equals",
-        "statusId_fld1_grp": "2",
-        "productStoreId_fld0_value": this.state.user.currentEComStore.productStoreId,
-        "productStoreId_fld0_op": "equals",
-        "productStoreId_fld0_grp": "2",
+        "statusId_value": "SERVICE_DRAFT",
+        "statusId_op": "equals",
+        "shopId_fld0_value": this.state.user.currentShopifyConfig?.shopId,
+        "shopId_fld0_grp": "3",
+        "shopId_fld0_op": "equals",
+        "shopId_fld1_grp": "4",
+        "shopId_fld1_op": "empty",
         ...payload.inputFields
       },
       "noConditionFind": "Y",
@@ -357,9 +368,29 @@ const actions: ActionTree<JobState, RootState> = {
     if (payload?.orderBy) {
       params['orderBy'] = payload.orderBy
     }
-    const resp = await JobService.fetchJobInformation(params)
+    fetchJobRequests.push(JobService.fetchJobInformation(params).catch((err) => {
+      return err;
+    }))
 
-    if (resp.status === 200 && !hasError(resp) && resp.data.docs) {
+    // Deep cloning in order to avoid mutating the same reference causing side effects
+    params =  JSON.parse(JSON.stringify(params));
+
+    // Fetching pending jobs
+    params.inputFields['statusId_value'] = "SERVICE_PENDING";
+    params.inputFields['statusId_op'] = "equals";
+    params.inputFields['productStoreId_value'] = this.state.user.currentEComStore.productStoreId;
+    params.inputFields['productStoreId_op'] = "equals";
+    fetchJobRequests.push(JobService.fetchJobInformation(params).catch((err) => {
+      return err;
+    }))
+
+    const resp = await Promise.all(fetchJobRequests)
+    const responseJobs = resp.reduce((responseJobs: any, response: any) => {
+      response.status === 200 && !hasError(response) && response.data.docs && (responseJobs = [...responseJobs, ...response.data.docs]);
+      return responseJobs;
+    }, [])
+
+    // TODO Fix Indentation
       const cached = JSON.parse(JSON.stringify(state.cached));
 
       // added condition to store multiple pending jobs in the state for order batch jobs,
@@ -375,7 +406,7 @@ const actions: ActionTree<JobState, RootState> = {
         batchJobEnumIds = batchJobEnumIds.filter((batchJobEnumId: any) => payload.inputFields.systemJobEnumId.includes(batchJobEnumId));
       }
       batchJobEnumIds.map((batchBrokeringJobEnum: any) => {
-        cached[batchBrokeringJobEnum] = resp.data.docs.filter((job: any) => job.systemJobEnumId === batchBrokeringJobEnum).reduce((batchBrokeringJobs: any, job: any) => {
+        cached[batchBrokeringJobEnum] = responseJobs.filter((job: any) => job.systemJobEnumId === batchBrokeringJobEnum).reduce((batchBrokeringJobs: any, job: any) => {
           batchBrokeringJobs.push({
             ...job,
             id: job.jobId,
@@ -388,7 +419,7 @@ const actions: ActionTree<JobState, RootState> = {
       })
       
       // added condition to store multiple pending jobs in the state for order batch jobs  
-      resp.data.docs.filter((job: any) => !batchJobEnumIds.includes(job.systemJobEnumId) && job.statusId === 'SERVICE_PENDING').reduce((cached: any, job: any) => {
+      responseJobs.filter((job: any) => !batchJobEnumIds.includes(job.systemJobEnumId) && job.statusId === 'SERVICE_PENDING').reduce((cached: any, job: any) => {
         cached[job.systemJobEnumId] = {
           ...job,
           id: job.jobId,
@@ -399,7 +430,7 @@ const actions: ActionTree<JobState, RootState> = {
         return cached;
       }, cached)  
 
-      resp.data.docs.filter((job: any) => job.statusId === 'SERVICE_DRAFT').map((job: any) => {
+      responseJobs.filter((job: any) => job.statusId === 'SERVICE_DRAFT').map((job: any) => {
         return cached[job.systemJobEnumId] = cached[job.systemJobEnumId] ? cached[job.systemJobEnumId] : {
           ...job,
           id: job.jobId,
@@ -414,7 +445,6 @@ const actions: ActionTree<JobState, RootState> = {
       await dispatch('fetchTemporalExpression', tempExpr)
 
       commit(types.JOB_UPDATED_BULK, cached);
-    }
     return resp;
   },
   async updateJob ({ commit, dispatch }, job) {

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -204,12 +204,9 @@ const actions: ActionTree<UserState, RootState> = {
   /**
    * update current shopify config id
    */
-  async setCurrentShopifyConfig({ commit }, shopifyConfig) {
+  async setCurrentShopifyConfig({ commit, dispatch }, shopifyConfig) {
     commit(types.USER_CURRENT_SHOPIFY_CONFIG_UPDATED, shopifyConfig);
-  },
-
-  async setEComStore({ commit }, payload) {
-    commit(types.USER_CURRENT_ECOM_STORE_UPDATED, payload.store);
+    dispatch('job/clearJobState', null, { root: true });
   },
 
   /**


### PR DESCRIPTION
When fetching jobs on various pages, shopId condition should be part of query in order to manage jobs based upon different shopify configuration Improved the logic for fetch job action to fetch draft and pending jobs separately. Cleared the jobs on shopify config change
Removed unused action in user state

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)