### PR TITLE
Fixed: runTime being set to current time while setting/updating time (#266)

### DIFF
--- a/src/components/InitialJobConfiguration.vue
+++ b/src/components/InitialJobConfiguration.vue
@@ -187,6 +187,7 @@ export default defineComponent({
 
       job['sinceId'] = this.lastShopifyOrderId
       job['jobStatus'] = job.tempExprId
+      job.runTime = this.runTime;
 
       // if job runTime is not a valid date then making runTime as empty
       if (job?.runTime && !isFutureDate(job?.runTime)) {

--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -300,6 +300,7 @@ export default defineComponent({
     async updateJob() {
       const job = this.currentJob;
       job['jobStatus'] = this.jobStatus !== 'SERVICE_DRAFT' ? this.jobStatus : 'HOURLY';
+      job.runTime = this.runTime;
 
       if (job?.statusId === 'SERVICE_DRAFT') {
         this.store.dispatch('job/scheduleService', job).then((job: any) => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://github.com/hotwax/job-manager/issues/266

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When setting jobs runtime initially or updating runtime for the existing job, the runtime is set to current time only. runtime should be set to user input value.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)