### PR TITLE
Fixed jobs not appearing after store change from Menu footer (#2a7ymj3)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -137,7 +137,7 @@ const actions: ActionTree<UserState, RootState> = {
       productStore = this.state.user.current.stores.find((store: any) => store.productStoreId === payload.productStoreId);
     }
     commit(types.USER_CURRENT_ECOM_STORE_UPDATED, productStore);
-    dispatch('getShopifyConfig',  productStore.productStoreId);
+    await dispatch('getShopifyConfig',  productStore.productStoreId);
     await UserService.setUserPreference({
       'userPrefTypeId': 'SELECTED_BRAND',
       'userPrefValue': productStore.productStoreId


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Jobs were not being fetched when the product store was changed rapidly from the menu footer. This was caused due to synchronous handling- on changing the store, the event to change the Shopify config is also fired. But due to synchronous handling, on rapid change, the Shopify config event gets run even before the store change event has finished, hence, the Shopify config was not being set, causing jobs to not render. This was handled by making the getShopifyConfigs action async using the 'await' keyword.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)