### PR TITLE
Fixed: the enumTypeId for bokering jobs(#85zrgnpuc)

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -127,7 +127,7 @@ export default defineComponent({
         name: "Brokering",
         iosIcon: compassOutline,
         mdIcon: compassOutline,
-        enumTypeId: "BROKERING_SYS_JOB"
+        enumTypeId: "BROKER_SYS_JOB"
       },
       {
         name: "Fulfillment",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Issue is due to the wrong enumId being used for brokering jobs

Closes #319 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the enumTypeId to `BROKER_SYS_JOB`

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)