### PR TITLE
Improved: user scheduleService action instead of runServiceNow (#423)

### DIFF
--- a/src/components/InitialJobConfiguration.vue
+++ b/src/components/InitialJobConfiguration.vue
@@ -200,7 +200,7 @@ export default defineComponent({
       }
 
       if (job?.statusId === 'SERVICE_DRAFT') {
-        this.store.dispatch('job/runServiceNow', job)
+        this.store.dispatch('job/scheduleService', job)
       } else if (job?.statusId === 'SERVICE_PENDING') {
         this.store.dispatch('job/updateJob', job)
       }

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -646,17 +646,6 @@ const actions: ActionTree<JobState, RootState> = {
       resp = await JobService.scheduleJob({ ...job.runtimeData, ...payload });
       if (resp.status == 200 && !hasError(resp)) {
         showToast(translate('Service has been scheduled'))
-        // TODO: need to check if we actually need to call fetchJobs when running a service now
-        // becuase when scheduling a service for run now, then the service goes in pending state for a small
-        // time and thus fetchJob api gets the info of that service as well, and when service is exceuted
-        // it is no more in pending state, but on app level we still have that service info with status
-        // pending
-        dispatch('fetchJobs', {
-          inputFields: {
-            'systemJobEnumId': payload.systemJobEnumId,
-            'systemJobEnumId_op': 'equals'
-          }
-        })
       } else {
         showToast(translate('Something went wrong'))
       }


### PR DESCRIPTION
Initial load job performs bulk operation and preferred to be run as system user. If the user associated with job is disabled, or password changes, the job may not run

Additional change:
Removed fetch jobs action cal for runServiceNow as the jobs which reflects through this action must have temp expression. Thus run now has no effect on current jobs.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #423 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)