### PR TITLE
Added: support to pass shopId to runtime data

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -511,10 +511,12 @@ const actions: ActionTree<JobState, RootState> = {
       'systemJobEnumId': job.systemJobEnumId
     } as any
     
-    if(job?.runtimeData?.shopifyConfigId) {
+    if (job?.runtimeData?.shopifyConfigId || job?.runtimeData?.shopId) {
       const shopifyConfig = this.state.user.currentShopifyConfig
-      payload['shopifyConfigId'] = shopifyConfig?.shopifyConfigId
-      payload['jobFields']['shopId'] = shopifyConfig?.shopId
+
+      job?.runtimeData?.shopifyConfigId && (payload['shopifyConfigId'] = shopifyConfig?.shopifyConfigId);
+      job?.runtimeData?.shopId && (payload['shopId'] = shopifyConfig?.shopId);
+      payload['jobFields']['shopId'] = shopifyConfig?.shopId;
     }
 
     // checking if the runtimeData has productStoreId, and if present then adding it on root level
@@ -626,9 +628,7 @@ const actions: ActionTree<JobState, RootState> = {
         'tempExprId': job.jobStatus, // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, currently kept it for backward compatibility
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone,
-        'shopId': job.runtimeData?.shopifyConfigId && job.status === "SERVICE_PENDING" ? job.shopId : this.state.user.currentShopifyConfig.shopId,
       },
-      'shopifyConfigId': job.runtimeData?.shopifyConfigId && job.status === "SERVICE_PENDING" ? job.runtimeData?.shopifyConfigId : this.state.user.currentShopifyConfig.shopifyConfigId,
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId
     } as any
@@ -636,6 +636,16 @@ const actions: ActionTree<JobState, RootState> = {
     job?.runtimeData?.productStoreId?.length >= 0 && (payload['productStoreId'] = job.status === "SERVICE_PENDING" ? job.productStoreId : this.state.user.currentEComStore.productStoreId)
     job?.priority && (payload['SERVICE_PRIORITY'] = job.priority.toString())
     job?.sinceId && (payload['sinceId'] = job.sinceId)
+
+    // ShopifyConfig and ShopifyShop should be set based upon runtime data
+    // If existing job is run now, copy as is else set the current shop of user
+    if (job?.runtimeData?.shopifyConfigId || job?.runtimeData?.shopId) {
+      const shopifyConfig = this.state.user.currentShopifyConfig
+
+      job?.runtimeData?.shopifyConfigId && (payload['shopifyConfigId'] = job.status === "SERVICE_PENDING" ? job.runtimeData?.shopifyConfigId  : shopifyConfig?.shopifyConfigId);
+      job?.runtimeData?.shopId && (job.status === "SERVICE_PENDING" ? job.runtimeData?.shopId  : shopifyConfig?.shopId);
+      payload['jobFields']['shopId'] = job.status === "SERVICE_PENDING" ? job.shopId  : shopifyConfig?.shopId;
+    }
 
     // assigning '' (empty string) to all the runtimeData properties whose value is "null"
     job.runtimeData && Object.keys(job.runtimeData).map((key: any) => {
@@ -804,13 +814,14 @@ const actions: ActionTree<JobState, RootState> = {
         } as any
 
         
-        if (job?.runtimeData?.shopifyConfigId) {
+        if (job?.runtimeData?.shopifyConfigId || job?.runtimeData?.shopId) {
           const shopifyConfig = this.state.user.shopifyConfigs.find((config: any) => {
             return config.shopId === shopId;
           })
 
-          params['shopifyConfigId'] = shopifyConfig.shopifyConfigId;
-          params['jobFields']['shopId'] = shopId;
+          job?.runtimeData?.shopifyConfigId && (params['shopifyConfigId'] = shopifyConfig.shopifyConfigId);
+          job?.runtimeData?.shopId && (params['shopId'] = shopifyConfig.shopId);
+          params['jobFields']['shopId'] = shopifyConfig.shopId;
         }
 
         // checking if the runtimeData has productStoreId, and if present then adding it on root level


### PR DESCRIPTION
Fixed schedule now should not pass the shopId and shopifyConfigId if the runtime data doesn't have such field

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)