### PR TITLE
Fixed: jobs list not updated when cancelling a job from configuration

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -413,6 +413,12 @@ const actions: ActionTree<JobState, RootState> = {
     // TODO Fix Indentation
     const cached = JSON.parse(JSON.stringify(state.cached));
 
+    // If individual job is fetched, this might be the case for update and cancel of job
+    // Old job should be removed and fetched again, in order to replace last pending one with draft job
+    if (payload.inputFields.systemJobEnumId && payload.inputFields.systemJobEnumId_op === "equals") {
+      delete cached[payload.inputFields.systemJobEnumId];
+    }
+
     // added condition to store multiple pending jobs in the state for order batch jobs,
     // getting job with status Service draft as well, as this information will be needed when scheduling
     // a new batch


### PR DESCRIPTION
As per the current logic, when fetching the jobs the draft jobs doesn't replace existing pending job in cached. When getting individual job, removed the cached job and then updated the cached as received from server

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)