### PR TITLE
Improved: Show toast if shopifyConfig required for the job is missing while scheduling (#502)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -215,6 +215,7 @@
   "Settings": "Settings",
   "Shop Config": "Shop Config",
   "Shopify Config": "Shopify Config",
+  "Shopify configuration not found. Scheduling failed.": "Shopify configuration not found. Scheduling failed.",
   "Shopify source": "Shopify source",
   "Skip": "Skip",
   "Skip job": "Skip job",

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -544,6 +544,10 @@ const actions: ActionTree<JobState, RootState> = {
     
     if (job?.runtimeData?.shopifyConfigId || job?.runtimeData?.shopId) {
       const shopifyConfig = this.state.user.currentShopifyConfig
+      if (Object.keys(shopifyConfig).length == 0) {
+        showToast(translate('Shopify configuration not found. Scheduling failed.'))
+        return;
+      }
 
       job?.runtimeData?.shopifyConfigId && (payload['shopifyConfigId'] = shopifyConfig?.shopifyConfigId);
       job?.runtimeData?.shopId && (payload['shopId'] = shopifyConfig?.shopId);
@@ -673,6 +677,10 @@ const actions: ActionTree<JobState, RootState> = {
     // If existing job is run now, copy as is else set the current shop of user
     if (job?.runtimeData?.shopifyConfigId || job?.runtimeData?.shopId) {
       const shopifyConfig = this.state.user.currentShopifyConfig
+      if (job.status !== "SERVICE_PENDING" && Object.keys(shopifyConfig).length == 0) {
+        showToast(translate('Shopify configuration not found. Scheduling failed.'))
+        return;
+      }
 
       job?.runtimeData?.shopifyConfigId && (payload['shopifyConfigId'] = job.status === "SERVICE_PENDING" ? job.runtimeData?.shopifyConfigId  : shopifyConfig?.shopifyConfigId);
       job?.runtimeData?.shopId && (payload['shopId'] = job.status === "SERVICE_PENDING" ? job.runtimeData?.shopId  : shopifyConfig?.shopId);


### PR DESCRIPTION

When scheduling a job, if the job runtime requires shopifyConfigId or shopId and it is missing in passed data, skip scheduling the job with a toast stating the reason

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #502 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)