### PR TITLE
Fixed: Displayed current time as per the user's timezone on date-time picker while scheduling jobs with custom runtime.

### DIFF
--- a/src/components/BatchModal.vue
+++ b/src/components/BatchModal.vue
@@ -37,7 +37,7 @@
     </ion-radio-group>
     <ion-item>
       <ion-label position="fixed">{{ $t("Schedule") }}</ion-label>
-      <ion-datetime hour-cycle="h12" :value="currentBatch?.runTime ? getDateTime(currentBatch.runTime) : ''" @ionChange="updateRunTime($event)" presentation="time" size="cover" />
+      <ion-datetime hour-cycle="h12" :value="currentBatch?.runTime ? getDateTime(currentBatch.runTime) : getNowTimestamp()" @ionChange="updateRunTime($event)" presentation="time" size="cover" />
     </ion-item>    
     <ion-fab @click="updateJob()" vertical="bottom" horizontal="end" slot="fixed">
       <ion-fab-button>
@@ -72,7 +72,7 @@ import { defineComponent } from 'vue';
 import { closeOutline, checkmarkDoneOutline } from 'ionicons/icons';
 import { mapGetters, useStore } from 'vuex';
 import { DateTime } from 'luxon';
-import { handleDateTimeInput, isFutureDate, showToast } from '@/utils';
+import { handleDateTimeInput, isFutureDate, showToast, getNowTimestamp } from '@/utils';
 import { translate } from '@/i18n'
 export default defineComponent({
   name: 'BatchModal',
@@ -179,7 +179,8 @@ export default defineComponent({
     return {
       checkmarkDoneOutline,
       closeOutline,
-      store
+      store,
+      getNowTimestamp
     };
   },
 });

--- a/src/components/InitialJobConfiguration.vue
+++ b/src/components/InitialJobConfiguration.vue
@@ -24,7 +24,7 @@
             <ion-datetime
               show-default-buttons
               hour-cycle="h23"
-              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : ''"
+              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : getNowTimestamp()"
               @ionChange="updateCustomTime($event)"
             />
           </ion-content>
@@ -60,7 +60,7 @@
             <ion-datetime          
               show-default-buttons
               hour-cycle="h12"
-              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : ''"
+              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : getNowTimestamp()"
               @ionChange="updateCustomTime($event)"
             />
           </ion-content>
@@ -125,7 +125,7 @@ import {
 import { mapGetters, useStore } from "vuex";
 import { translate } from "@/i18n";
 import { DateTime } from 'luxon';
-import { isCustomRunTime, generateAllowedRunTimes, handleDateTimeInput, isFutureDate, showToast } from '@/utils';
+import { isCustomRunTime, getNowTimestamp, generateAllowedRunTimes, handleDateTimeInput, isFutureDate, showToast } from '@/utils';
 import { Actions, hasPermission } from '@/authorization'
 import { JobService } from "@/services/JobService";
 
@@ -268,6 +268,7 @@ export default defineComponent({
       flagOutline,
       hasPermission,
       isCustomRunTime,
+      getNowTimestamp,
       sendOutline,
       store,
       timeOutline

--- a/src/components/InitialJobConfiguration.vue
+++ b/src/components/InitialJobConfiguration.vue
@@ -216,7 +216,7 @@ export default defineComponent({
 
       // Handling the case for 'Now'. Sending the now value will fail the API as by the time
       // the job is ran, the given 'now' time would have passed. Hence, passing empty 'run time'
-      job.runTime = !isCustomRunTime(this.runTime) ? DateTime.now().toMillis() + this.runTime : this.runTime
+      job.runTime = this.runTime != 0 ? (!isCustomRunTime(this.runTime) ? DateTime.now().toMillis() + this.runTime : this.runTime) : ''
 
       // if job runTime is not a valid date then making runTime as empty
       if (job?.runTime && !isFutureDate(job?.runTime)) {

--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -30,7 +30,7 @@
             <ion-datetime          
               show-default-buttons
               hour-cycle="h23"
-              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : ''"
+              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(DateTime.now().toMillis()) : getDateTime(DateTime.now().toMillis() + runTime)) : getNowTimestamp()"
               @ionChange="updateCustomTime($event)"
             />
           </ion-content>
@@ -126,7 +126,7 @@ import {
 } from "ionicons/icons";
 import JobHistoryModal from '@/components/JobHistoryModal.vue'
 import { Plugins } from '@capacitor/core';
-import { isCustomRunTime, generateAllowedRunTimes, generateAllowedFrequencies, handleDateTimeInput, showToast, hasError } from "@/utils";
+import { isCustomRunTime, getNowTimestamp, generateAllowedRunTimes, generateAllowedFrequencies, handleDateTimeInput, showToast, hasError } from "@/utils";
 import { mapGetters, useStore } from "vuex";
 import { DateTime } from 'luxon';
 import { translate } from '@/i18n'
@@ -413,6 +413,7 @@ export default defineComponent({
       flashOutline,
       hasPermission,
       isCustomRunTime,
+      getNowTimestamp,
       timeOutline,
       timerOutline,
       store,

--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -294,7 +294,7 @@ export default defineComponent({
 
       // Handling the case for 'Now'. Sending the now value will fail the API as by the time
       // the job is ran, the given 'now' time would have passed. Hence, passing empty 'run time'
-      job.runTime = !isCustomRunTime(this.runTime) ? DateTime.now().toMillis() + this.runTime : this.runTime
+      job.runTime = this.runTime != 0 ? (!isCustomRunTime(this.runTime) ? DateTime.now().toMillis() + this.runTime : this.runTime) : ''
 
       if (job?.statusId === 'SERVICE_DRAFT') {
         this.store.dispatch('job/scheduleService', job).then((job: any) => {

--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -30,7 +30,7 @@
             <ion-datetime          
               show-default-buttons
               hour-cycle="h23"
-              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(DateTime.now().toMillis()) : getDateTime(DateTime.now().toMillis() + runTime)) : getNowTimestamp()"
+              :value="runTime ? (isCustomRunTime(runTime) ? getDateTime(runTime) : getDateTime(DateTime.now().toMillis() + runTime)) : getNowTimestamp()"
               @ionChange="updateCustomTime($event)"
             />
           </ion-content>

--- a/src/components/JobConfigurationForBulkScheduler.vue
+++ b/src/components/JobConfigurationForBulkScheduler.vue
@@ -28,7 +28,7 @@
           <ion-datetime 
             show-default-buttons 
             hour-cycle="h23" 
-            :value="job.runTime ? (isCustomRunTime(job.runTime) ? getDateTime(job.runTime) : getDateTime(DateTime.now().toMillis() + job.runTime)) : ''"
+            :value="job.runTime ? (isCustomRunTime(job.runTime) ? getDateTime(job.runTime) : getDateTime(DateTime.now().toMillis() + job.runTime)) : getNowTimestamp()"
             @ionChange="updateCustomTime($event)"
           />
         </ion-content>
@@ -79,7 +79,7 @@ import {
   closeOutline
 } from "ionicons/icons";
 import { mapGetters, useStore } from "vuex";
-import { isCustomRunTime, generateAllowedRunTimes, generateAllowedFrequencies, handleDateTimeInput, showToast } from "@/utils";
+import { isCustomRunTime, getNowTimestamp, generateAllowedRunTimes, generateAllowedFrequencies, handleDateTimeInput, showToast } from "@/utils";
 import { DateTime } from 'luxon';
 import { translate } from '@/i18n'
 import { Actions, hasPermission } from '@/authorization'
@@ -207,6 +207,7 @@ export default defineComponent({
       DateTime,
       flashOutline,
       isCustomRunTime,
+      getNowTimestamp,
       timeOutline,
       timerOutline,
       store,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -202,8 +202,13 @@ const isCustomRunTime = (value: number) => {
   return !generateAllowedRunTimes().some((runTime: any) => runTime.value === value)
 }
 
+const getNowTimestamp = () => {
+  return DateTime.now().toISO();
+}
+
 export {
   isCustomRunTime,
+  getNowTimestamp,
   generateAllowedFrequencies,
   generateAllowedRunTimes,
   handleDateTimeInput,

--- a/src/views/BulkEditor.vue
+++ b/src/views/BulkEditor.vue
@@ -59,7 +59,7 @@
                 <ion-datetime            
                   show-default-buttons 
                   hour-cycle="h23" 
-                  :value="globalRuntime ? (isCustomRunTime(globalRuntime) ? getDateTime(globalRuntime) : getDateTime(DateTime.now().toMillis() + globalRuntime)) : ''"
+                  :value="globalRuntime ? (isCustomRunTime(globalRuntime) ? getDateTime(globalRuntime) : getDateTime(DateTime.now().toMillis() + globalRuntime)) : getNowTimestamp"
                   @ionChange="updateCustomTime($event)"
                 />
               </ion-content>
@@ -126,7 +126,7 @@ import { addOutline, iceCreamOutline, timeOutline, timerOutline } from 'ionicons
 import { useRouter } from 'vue-router';
 import SelectJobsModal from '@/views/SelectJobsModal.vue';
 import { UserService } from '@/services/UserService'
-import { isCustomRunTime, generateAllowedRunTimes, generateAllowedFrequencies, hasError, showToast, handleDateTimeInput } from '@/utils'
+import { isCustomRunTime, getNowTimestamp, generateAllowedRunTimes, generateAllowedFrequencies, hasError, showToast, handleDateTimeInput } from '@/utils'
 import { translate } from '@/i18n'
 import JobConfigurationForBulkScheduler from '@/components/JobConfigurationForBulkScheduler.vue'
 import { DateTime } from 'luxon';
@@ -190,6 +190,7 @@ export default defineComponent({
       DateTime,
       iceCreamOutline,
       isCustomRunTime,
+      getNowTimestamp,
       store,
       router,
       timeOutline,

--- a/src/views/BulkEditor.vue
+++ b/src/views/BulkEditor.vue
@@ -59,7 +59,7 @@
                 <ion-datetime            
                   show-default-buttons 
                   hour-cycle="h23" 
-                  :value="globalRuntime ? (isCustomRunTime(globalRuntime) ? getDateTime(globalRuntime) : getDateTime(DateTime.now().toMillis() + globalRuntime)) : getNowTimestamp"
+                  :value="globalRuntime ? (isCustomRunTime(globalRuntime) ? getDateTime(globalRuntime) : getDateTime(DateTime.now().toMillis() + globalRuntime)) : getNowTimestamp()"
                   @ionChange="updateCustomTime($event)"
                 />
               </ion-content>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #532 #525

### Short Description and Why It's Useful
Fixed: Displayed current time as per the user's timezone on date-time picker while scheduling jobs with custom runtime.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)