### PR TITLE
Implemented: Page Selection Persistence for Job Manager App with Side Navigation (#122)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -12,7 +12,6 @@
           <ion-item
             v-if="page.url"
             button
-            @click="selectedIndex = index"
             router-direction="root"
             :router-link="page.url"
             class="hydrated"
@@ -81,12 +80,13 @@ import {
   IonTitle,
   IonToolbar
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent } from "vue";
 import { mapGetters } from "vuex";
 import { albumsOutline, barChartOutline, calendarNumberOutline, iceCreamOutline, libraryOutline, pulseOutline, settingsOutline, shirtOutline, terminalOutline, ticketOutline } from "ionicons/icons";
 import { useStore } from "@/store";
 import emitter from "@/event-bus"
 import { hasPermission } from "@/authorization";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "Menu",
@@ -106,12 +106,6 @@ export default defineComponent({
     IonSelectOption,
     IonTitle,
     IonToolbar
-  },
-  created() {
-    // When open any specific screen it should show that screen selected
-    this.selectedIndex = this.appPages.findIndex((screen) => {
-      return screen.url === this.$router.currentRoute.value.path;
-    })
   },
   computed: {
     ...mapGetters({
@@ -140,17 +134,9 @@ export default defineComponent({
       return appPages.filter((appPage: any) => (!appPage.meta || !appPage.meta.permissionId) || hasPermission(appPage.meta.permissionId));
     }
   },
-  watch:{
-    $route (to, from) {
-      // When logout and login it should point to Oth index
-      if (from.path === '/login') {
-        this.selectedIndex = 0;
-      }
-    },
-  }, 
   setup() {
     const store = useStore();
-    const selectedIndex = ref(0);
+    const router = useRouter();
     let appPages = [
       {
         title: "Pipeline",
@@ -254,11 +240,17 @@ export default defineComponent({
         iosIcon: settingsOutline,
         mdIcon: settingsOutline,
         dependsOnBaseURL: true
-      },
-    ];
+      }
+    ] as any;
     if (process.env.VUE_APP_BASE_URL) {
-      appPages = appPages.filter((page) => page.dependsOnBaseURL);
+      appPages = appPages.filter((page : any) => page.dependsOnBaseURL);
     }
+
+    const selectedIndex = computed(() => {
+      const path = router.currentRoute.value.path
+      return appPages.findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path))
+    })
+
     return {
       albumsOutline,
       appPages,
@@ -275,7 +267,7 @@ export default defineComponent({
       terminalOutline,
       ticketOutline,
     };
-  },
+  }
 });
 </script>
 


### PR DESCRIPTION
### Related Issues
Related issue: https://github.com/hotwax/dxp-components/issues/122

### Short Description and Why It's Useful
Fixed issue of menu not being enabled for the correct page when using the back button in Job Manager app.
- Removed a watcher from the menu component that checks for route changes
- Defined a computed property to find the correct index in the menu list



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)