### PR TITLE
Improved: Added empty state text for jobs with no custom parameters (#605)

### DIFF
--- a/src/components/JobParameterModal.vue
+++ b/src/components/JobParameterModal.vue
@@ -34,7 +34,7 @@
         </ion-item>
       </ion-item-group>
       <ion-item v-else lines="none">
-        <ion-label class="ion-text-center" >There are no custom parameters for this job</ion-label>
+        <ion-label class="ion-text-center" >This job does not have any custom parameters.</ion-label>
       </ion-item>
     </ion-list>
   </ion-content>

--- a/src/components/JobParameterModal.vue
+++ b/src/components/JobParameterModal.vue
@@ -9,8 +9,8 @@
   </ion-header>
 
   <ion-content>
-    <ion-list>
-      <ion-item-group v-if="customRequiredParameters.length || customOptionalParameters.length">
+    <ion-list v-if="customRequiredParameters.length || customOptionalParameters.length">
+      <ion-item-group>
         <ion-item-divider v-if="customRequiredParameters.length" color="light">
           <ion-label>{{ $t('Required Parameters') }}</ion-label>
         </ion-item-divider>
@@ -33,10 +33,10 @@
           <ion-note slot="helper">{{ parameter.type }}</ion-note>
         </ion-item>
       </ion-item-group>
-      <ion-item v-else lines="none">
-        <ion-label class="ion-text-center" >{{ $t('This job does not have any custom parameters.') }}</ion-label>
-      </ion-item>
     </ion-list>
+    <ion-item v-else lines="none">
+      <ion-label class="ion-text-center" >{{ $t('This job does not have any custom parameters.') }}</ion-label>
+    </ion-item>
   </ion-content>
 </template>
 

--- a/src/components/JobParameterModal.vue
+++ b/src/components/JobParameterModal.vue
@@ -10,7 +10,7 @@
 
   <ion-content>
     <ion-list>
-      <ion-item-group>
+      <ion-item-group v-if="customRequiredParameters.length || customOptionalParameters.length">
         <ion-item-divider v-if="customRequiredParameters.length" color="light">
           <ion-label>{{ $t('Required Parameters') }}</ion-label>
         </ion-item-divider>
@@ -33,6 +33,9 @@
           <ion-note slot="helper">{{ parameter.type }}</ion-note>
         </ion-item>
       </ion-item-group>
+      <ion-item v-else lines="none">
+        <ion-label class="ion-text-center" >There are no custom parameters for this job</ion-label>
+      </ion-item>
     </ion-list>
   </ion-content>
 </template>

--- a/src/components/JobParameterModal.vue
+++ b/src/components/JobParameterModal.vue
@@ -34,7 +34,7 @@
         </ion-item>
       </ion-item-group>
       <ion-item v-else lines="none">
-        <ion-label class="ion-text-center" >This job does not have any custom parameters.</ion-label>
+        <ion-label class="ion-text-center" >{{ $t('This job does not have any custom parameters.') }}</ion-label>
       </ion-item>
     </ion-list>
   </ion-content>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -260,6 +260,7 @@
   "This job has slow frequency type, hence, feasible frequency will be set automatically": "This job has slow frequency type, hence, feasible frequency will be set automatically",
   "This job may take several minutes to run. Wait till the job has moved to the pipeline history before checking results.": "This job may take several minutes to run.{ space } Wait till the job has moved to the pipeline history before checking results.",
   "This job schedule cannot be skipped": "This job schedule cannot be skipped",
+  "This job does not have any custom parameters.": "This job does not have any custom parameters.",
   "Time zone updated successfully": "Time zone updated successfully",
   "Timezone": "Timezone",
   "Tomorrow": "Tomorrow",


### PR DESCRIPTION
### Related Issues
Closes #605

### Short Description and Why It's Useful
Added an empty state text for jobs with no custom parameters in the orders page in the job-manager app.


### Screenshots of Visual Changes before/after (If There Are Any)
Before
![Screenshot from 2023-08-24 11-44-50](https://github.com/hotwax/job-manager/assets/69574321/fab274a0-ee7d-4b53-b91a-32ac84400926)

After
![Screenshot from 2023-08-24 12-34-04](https://github.com/hotwax/job-manager/assets/69574321/52dce094-437f-406f-a960-1d1266b89503)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)