### PR TITLE
Removed: spacing after param name when displaying the custom parameters for a job

### DIFF
--- a/src/components/InitialJobConfiguration.vue
+++ b/src/components/InitialJobConfiguration.vue
@@ -38,7 +38,7 @@
         </ion-chip>
         <ion-row v-else>
           <ion-chip @click="openJobCustomParameterModal" outline :color="value ? undefined :'danger'" :key="name" v-for="(value, name) in generateCustomParameters">
-            {{ name }} : {{ value }}
+            {{ name }}: {{ value }}
           </ion-chip>
         </ion-row>
         <ion-button @click="openJobCustomParameterModal" id="open-modal" slot="end" fill="clear">
@@ -117,7 +117,7 @@
         </ion-chip>
         <ion-row v-else>
           <ion-chip @click="openJobCustomParameterModal" outline :color="value ? undefined :'danger'" :key="name" v-for="(value, name) in generateCustomParameters">
-            {{ name }} : {{ value }}
+            {{ name }}: {{ value }}
           </ion-chip>
         </ion-row>
         <ion-button @click="openJobCustomParameterModal" id="open-modal" slot="end" fill="clear">

--- a/src/components/JobConfiguration.vue
+++ b/src/components/JobConfiguration.vue
@@ -52,7 +52,7 @@
         </ion-chip>
         <ion-row v-else>
           <ion-chip @click="openJobCustomParameterModal" outline :color="value ? undefined :'danger'" :key="name" v-for="(value, name) in generateCustomParameters">
-            {{ name }} : {{ value }}
+            {{ name }}: {{ value }}
           </ion-chip>
         </ion-row>
         <ion-button @click="openJobCustomParameterModal" id="open-modal" slot="end" fill="clear">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

![image](https://github.com/hotwax/job-manager/assets/41404838/24f946c5-5dd3-4ce9-9e46-2879a51c9e90)


After:

![image](https://github.com/hotwax/job-manager/assets/41404838/16d90f45-c3af-4ac9-b0f8-bb9cb18ada94)




**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)