### PR TITLE
Improved: Enabled sorting based on lastUpdatedStamp of Job while fetching completed jobs.

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -56,7 +56,7 @@ const actions: ActionTree<JobState, RootState> = {
       "noConditionFind": "Y",
       "viewSize": payload.viewSize,
       "viewIndex": payload.viewIndex,
-      "orderBy": "runTime DESC"
+      "orderBy": "lastUpdatedStamp DESC | runTime DESC"
     }
 
     if(payload.statusId.length > 0) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #594 

### Short Description and Why It's Useful
Improved: Enabled sorting based on lastUpdatedStamp of Job while fetching completed jobs. So now recently updated jobs will come first.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)