### PR TITLE
Improved: job fetching query when clicking on a job panel to open job configuration (#619)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -767,6 +767,10 @@ const actions: ActionTree<JobState, RootState> = {
       return currentJob;
     }
 
+    if(!payload.jobId) {
+      return;
+    }
+
     let resp;
     try {
       const params = {

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -759,16 +759,16 @@ const actions: ActionTree<JobState, RootState> = {
       return payload?.job;
     }
 
+    if(!payload.jobId) {
+      return;
+    }
+
     let currentJob = pendingJobs.find((job: any) => job.jobId === payload.jobId);
     currentJob = currentJob ? currentJob : cachedJobs[payload?.jobId];
 
     if(currentJob) {
       commit(types.JOB_CURRENT_UPDATED, currentJob);
       return currentJob;
-    }
-
-    if(!payload.jobId) {
-      return;
     }
 
     let resp;

--- a/src/views/Brokering.vue
+++ b/src/views/Brokering.vue
@@ -222,7 +222,10 @@ export default defineComponent({
         this.currentJob.runTime = ''
       }
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob, jobId: this.jobEnums[jobInformation.id] });
+
+      if(job) this.currentJob = job;
+
       if(!this.isDesktop && this.currentJob) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.currentJob.jobId, category: "orders" } });
         return;

--- a/src/views/Fulfillment.vue
+++ b/src/views/Fulfillment.vue
@@ -249,7 +249,10 @@ export default defineComponent({
         this.currentJob.runTime = ''
       }
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob, jobId: this.jobEnums[jobInformation.id] });
+
+      if(job) this.currentJob = job;
+
       if(!this.isDesktop && this.currentJob) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.currentJob.jobId, category: "orders" } });
         return;

--- a/src/views/InitialLoad.vue
+++ b/src/views/InitialLoad.vue
@@ -179,11 +179,6 @@ export default defineComponent({
       this.currentSelectedJobModal = label;
       this.job = this.getJob(id);
 
-      if (!this.job) {
-        showToast(translate('Configuration missing'))
-        return;
-      }
-
       if(this.job?.runtimeData?.sinceId?.length >= 0) {
         this.lastShopifyOrderId = this.job.runtimeData.sinceId !== 'null' ? this.job.runtimeData.sinceId : ''
       }
@@ -192,7 +187,9 @@ export default defineComponent({
         this.job.runTime = ''
       }
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.job });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.job, jobId: id });
+      if(job) this.job = job;
+
       if(!this.isDesktop && this.job) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.job.jobId, category: "initial-load" } });
         return;

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -185,7 +185,9 @@ export default defineComponent({
       this.currentJobStatus = jobInformation.status;
       this.freqType = jobInformation.id && this.jobFrequencyType[jobInformation.id]
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob, jobId: this.jobEnums[jobInformation.id] });
+      if(job) this.currentJob = job;
+
       if(!this.isDesktop && this.currentJob) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.currentJob.jobId, category: "inventory" } });
         return;

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -241,7 +241,10 @@ export default defineComponent({
         this.currentJob.runTime = ''
       }
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob, jobId: this.jobEnums[jobInformation.id] });
+
+      if(job) this.currentJob = job;
+
       if(!this.isDesktop && this.currentJob) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.currentJob.jobId, category: "orders" } });
         return;

--- a/src/views/Product.vue
+++ b/src/views/Product.vue
@@ -40,7 +40,7 @@
               <ion-toggle slot="end" :disabled="!hasPermission(Actions.APP_JOB_UPDATE)" :checked="deleteProductsWebhook" @ionChange="updateWebhook($event['detail'].checked, 'DELETE_PRODUCTS')" color="secondary" />
             </ion-item>
           </ion-card>
-          <MoreJobs v-if="getMoreJobs({...jobEnums, ...initialLoadJobEnums}, enumTypeId).length" :jobs="getMoreJobs({...jobEnums, ...initialLoadJobEnums}, enumTypeId).length" />
+          <MoreJobs v-if="getMoreJobs({...jobEnums, ...initialLoadJobEnums}, enumTypeId).length" :jobs="getMoreJobs({...jobEnums, ...initialLoadJobEnums}, enumTypeId)" />
         </section>
 
         <aside class="desktop-only" v-if="isDesktop" v-show="currentJob">
@@ -157,7 +157,10 @@ export default defineComponent({
       this.currentJobStatus = jobInformation.status;
       this.freqType = jobInformation.id && this.jobFrequencyType[jobInformation.id]
 
-      await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob });
+      const job = await this.store.dispatch('job/updateCurrentJob', { job: this.currentJob, jobId: this.jobEnums[jobInformation.id] });
+
+      if(job) this.currentJob = job;
+
       if(!this.isDesktop && this.currentJob) {
         this.router.push({ name: 'JobDetails', params: { jobId: this.currentJob.jobId, category: "product" } });
         return;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #619

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When fetchJobs actions fails while rendering a page, clicking a job doesn't get job. Hence updated updateCurrentJob parameters so as to successfully fetch job info once already failed at the time of page rendering.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)