### PR TITLE
Fixed: case to empty the runTime epoch when updating a job or skipping a job

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -514,7 +514,7 @@ const actions: ActionTree<JobState, RootState> = {
       'recurrenceTimeZone': this.state.user.current.userTimeZone,
       'tempExprId': job.jobStatus,
       'statusId': "SERVICE_PENDING",
-      'runTimeEpoch': ''
+      'runTimeEpoch': ''  // when updating a job clearning the epoch time, as job honors epoch time as runTime and the new job created also uses epoch time as runTime
     } as any
 
     job?.runTime && (payload['runTime'] = job.runTime)

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -513,7 +513,8 @@ const actions: ActionTree<JobState, RootState> = {
       'systemJobEnumId': job.systemJobEnumId,
       'recurrenceTimeZone': this.state.user.current.userTimeZone,
       'tempExprId': job.jobStatus,
-      'statusId': "SERVICE_PENDING"
+      'statusId': "SERVICE_PENDING",
+      'runTimeEpoch': ''
     } as any
 
     job?.runTime && (payload['runTime'] = job.runTime)
@@ -650,7 +651,8 @@ const actions: ActionTree<JobState, RootState> = {
       'runTime': updatedRunTime,
       'systemJobEnumId': job.systemJobEnumId,
       'recurrenceTimeZone': this.state.user.current.userTimeZone,
-      'statusId': "SERVICE_PENDING"
+      'statusId': "SERVICE_PENDING",
+      'runTimeEpoch': ''
     } as any
 
     const resp = await JobService.updateJob(payload)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)