### PR TITLE
Improved: Set createdByUserLogin and lastModifiedByUserLogin while scheduling/updating jobs (#647).

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -514,7 +514,8 @@ const actions: ActionTree<JobState, RootState> = {
       'recurrenceTimeZone': this.state.user.current.userTimeZone,
       'tempExprId': job.jobStatus,
       'statusId': "SERVICE_PENDING",
-      'runTimeEpoch': ''  // when updating a job clearning the epoch time, as job honors epoch time as runTime and the new job created also uses epoch time as runTime
+      'runTimeEpoch': '',  // when updating a job clearning the epoch time, as job honors epoch time as runTime and the new job created also uses epoch time as runTime
+      'lastModifiedByUserLogin': this.state.user.current.userLoginId
     } as any
 
     job?.runTime && (payload['runTime'] = job.runTime)
@@ -566,7 +567,9 @@ const actions: ActionTree<JobState, RootState> = {
         'maxRecurrenceCount': '-1',
         'parentJobId': job.parentJobId,
         'runAsUser': 'system', //default system, but empty in run now.  TODO Need to remove this as we are using SERVICE_RUN_AS_SYSTEM, currently kept it for backward compatibility
-        'recurrenceTimeZone': this.state.user.current.userTimeZone
+        'recurrenceTimeZone': this.state.user.current.userTimeZone,
+        'createdByUserLogin': this.state.user.current.userLoginId,
+        'lastModifiedByUserLogin': this.state.user.current.userLoginId,
       },
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId,
@@ -694,6 +697,8 @@ const actions: ActionTree<JobState, RootState> = {
         'tempExprId': job.jobStatus, // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, currently kept it for backward compatibility
         'parentJobId': job.parentJobId,
         'recurrenceTimeZone': this.state.user.current.userTimeZone,
+        'createdByUserLogin': this.state.user.current.userLoginId,
+        'lastModifiedByUserLogin': this.state.user.current.userLoginId
       },
       'statusId': "SERVICE_PENDING",
       'systemJobEnumId': job.systemJobEnumId,
@@ -892,7 +897,9 @@ const actions: ActionTree<JobState, RootState> = {
             'maxRecurrenceCount': '-1',
             'parentJobId': job.parentJobId,
             'runAsUser': 'system', //default system, but empty in run now.  TODO Need to remove this as we are using SERVICE_RUN_AS_SYSTEM, currently kept it for backward compatibility
-            'recurrenceTimeZone': this.state.user.current.userTimeZone
+            'recurrenceTimeZone': this.state.user.current.userTimeZone,
+            'createdByUserLogin': this.state.user.current.userLoginId,
+            'lastModifiedByUserLogin': this.state.user.current.userLoginId
           },
           'statusId': "SERVICE_PENDING",
           'systemJobEnumId': job.systemJobEnumId


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #647 

### Short Description and Why It's Useful
Improved: Set createdByUserLogin and lastModifiedByUserLogin while scheduling/updating jobs (#647).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)