### PR TITLE
Implemented: button for copying failed job reason in the modal

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,7 @@
   "Completed orders": "Completed orders",
   "Configuration missing": "Configuration missing",
   "Copied job details to clipboard": "Copied job details to clipboard",
+  "Copied to clipboard": "Copied to clipboard",
   "Copy details": "Copy details",
   "Custom": "Custom",
   "Custom frequency": "Custom frequency",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ import Papa from 'papaparse'
 import { DateTime } from "luxon";
 import logger from "@/logger";
 import { translate } from "@/i18n";
+import { Plugins } from '@capacitor/core';
 
 // TODO Use separate files for specific utilities
 
@@ -330,7 +331,19 @@ const hasJobDataError = (job: any) => {
   return false;
 }
 
+const copyToClipboard = async (value: string, text?: string) => {
+  const { Clipboard } = Plugins;
+
+  await Clipboard.write({
+    string: value,
+  }).then(() => {
+    text ? showToast(translate(text)) : showToast(translate("Copied", { value }));
+  });
+}
+
+
 export {
+  copyToClipboard,
   isCustomRunTime,
   getNowTimestamp,
   generateAllowedFrequencies,

--- a/src/views/FailedJobReasonModal.vue
+++ b/src/views/FailedJobReasonModal.vue
@@ -7,6 +7,11 @@
         </ion-button>
       </ion-buttons>
       <ion-title>{{ $t("Failed job reason") }}</ion-title>
+      <ion-buttons slot="end">
+        <ion-button @click="copyToClipboard(job.jobResult, 'Copied to clipboard')">
+          <ion-icon slot="icon-only" :icon="copyOutline" />
+        </ion-button>
+      </ion-buttons>
     </ion-toolbar>
   </ion-header>
   <ion-content>
@@ -29,7 +34,8 @@ import {
   modalController,
 } from '@ionic/vue';
 import { defineComponent } from 'vue';
-import { closeOutline } from 'ionicons/icons';
+import { closeOutline, copyOutline } from 'ionicons/icons';
+import { copyToClipboard } from "@/utils";
 
 export default defineComponent({
   name: "FailedJobReasonModal",
@@ -51,7 +57,9 @@ export default defineComponent({
   },
   setup() {
     return {
-      closeOutline
+      closeOutline,
+      copyOutline,
+      copyToClipboard
     };
   },
 });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented button for copying failed job reason from the modal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-12-27 16-33-39](https://github.com/hotwax/job-manager/assets/69574321/44c26bbf-51d6-484d-9ca9-cf063b0f41b9)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)