### PR TITLE
Implemented: Spinner in timezone modal so users can see that data is being fetched

### DIFF
--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -22,9 +22,9 @@
           {{ $t("Fetching time zones") }}
         </ion-item>
       </div>
-    <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
-      <p>{{ $t("No time zone found") }}</p>
-    </div>
+      <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+        <p>{{ $t("No time zone found") }}</p>
+      </div>
 
       <!-- Timezones -->
       <div v-else>

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -16,12 +16,12 @@
   <ion-content class="ion-padding">
     <!-- Empty state -->
     <form @keyup.enter="setUserTimeZone">
-    <div class="empty-state" v-if="isLoading">
-      <ion-item lines="none">
-        <ion-spinner color="secondary" name="crescent" slot="start" />
-        {{ $t("Fetching time zones") }}
-      </ion-item>
-    </div>
+      <div class="empty-state" v-if="isLoading">
+        <ion-item lines="none">
+          <ion-spinner color="secondary" name="crescent" slot="start" />
+          {{ $t("Fetching time zones") }}
+        </ion-item>
+      </div>
     <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
       <p>{{ $t("No time zone found") }}</p>
     </div>

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -14,16 +14,17 @@
   </ion-header>
 
   <ion-content class="ion-padding">
+    <!-- Empty state -->
     <form @keyup.enter="setUserTimeZone">
-      <div class="empty-state" v-if="isLoading">
-        <ion-spinner name="crescent" />
-        <p>{{ $t("Fetching TimeZones")}}</p>
-      </div>
-
-      <!-- Empty state -->
-      <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
-        <p>{{ $t("No time zone found")}}</p>
-      </div>
+    <div class="empty-state" v-if="isLoading">
+      <ion-item lines="none">
+        <ion-spinner color="secondary" name="crescent" slot="start" />
+        {{ $t("Fetching time zones") }}
+      </ion-item>
+    </div>
+    <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+      <p>{{ $t("No time zone found") }}</p>
+    </div>
 
       <!-- Timezones -->
       <div v-else>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Spinner is added to show that the timezones are being fetched from the API. It is indicating to the user that the data is loading.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot 2024-01-06 093850](https://github.com/hotwax/inventory-count/assets/83332530/348205af-8a58-4280-81f0-4ef0d4f035c7)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)