### PR TITLE
Improved: login code to allow user to login without shopifyShop association (#685)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,4 +1,5 @@
 import { api, client } from '@/adapter';
+import logger from '@/logger';
 import store from '@/store';
 import { hasError } from '@/utils'
 
@@ -56,13 +57,14 @@ const getShopifyConfig = async (productStoreId: any, token?: any): Promise <any>
     }
     payload.baseURL = store.getters['user/getBaseUrl'];
     const resp = await client(payload);
-    if (hasError(resp)) {
-      return Promise.reject(resp?.data);
-    } else {
+    if (!hasError(resp)) {
       return Promise.resolve(resp?.data.docs);
+    } else {
+      throw resp.data
     }
   } catch(error: any) {
-    return Promise.reject(error)
+    logger.error(error)
+    return Promise.resolve([])
   }
 }
 
@@ -241,13 +243,14 @@ const getPreferredShopifyShop = async (token: any): Promise<any> => {
         'userPrefTypeId': 'FAVORITE_SHOPIFY_SHOP'
       },
     });
-    if (hasError(resp)) {
-      return Promise.reject(resp?.data);
-    } else {
+    if (!hasError(resp)) {
       return Promise.resolve(resp?.data.userPrefValue);
+    } else {
+      throw resp.data
     }
   } catch(error: any) {
-    return Promise.reject(error)
+    logger.error(error)
+    return Promise.reject(null)
   }
   
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -250,7 +250,7 @@ const getPreferredShopifyShop = async (token: any): Promise<any> => {
     }
   } catch(error: any) {
     logger.error(error)
-    return Promise.reject(null)
+    return Promise.resolve(null)
   }
   
 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #685

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved the login logic such that whenver a user login with no shopify config associated we will not stop them and allow them to login.

- The jobs which uses shopifyConfigId for scheduling and running will not be displayed in the app when we don't have any associated shopifyConfig.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)