### PR TITLE
Updated: webhook functionality to Automate Payment Marking for Shopify Orders(#700)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -97,6 +97,7 @@
   "Fulfilled": "Fulfilled",
   "Fulfillment": "Fulfillment",
   "Fulfillment status": "Fulfillment status",
+  "Get Paid Transactions": "Get Paid Transactions",
   "Go to OMS": "Go to OMS",
   "Go to Launchpad": "Go to Launchpad",
   "Hard sync": "Hard sync",

--- a/src/services/WebhookService.ts
+++ b/src/services/WebhookService.ts
@@ -20,8 +20,8 @@ const webhookParameters = {
     'endpoint': 'cancelOrderShopifyWebhook'
   },
   'PAYMENT_STATUS': {
-    'topic': 'orders/paid',
-    'endpoint': 'orderPaidNotificationFromShopify'
+    'topic': 'order_transactions/create',
+    'endpoint': 'getTransactionAndMarkOrderPaid'
   },
   'RETURNS': {
     'topic': 'refunds/create',

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -56,7 +56,7 @@
             </ion-item>
             <ion-item>
               <ion-toggle :disabled="!hasPermission(Actions.APP_JOB_UPDATE)" :checked="isPaymentStatus" @ionChange="updateWebhook($event['detail'].checked, 'PAYMENT_STATUS')" color="secondary">
-                <ion-label class="ion-text-wrap">{{ translate("Payment status") }}</ion-label>
+                <ion-label class="ion-text-wrap">{{ translate("Get Paid Transactions") }}</ion-label>
               </ion-toggle>
             </ion-item>
             <ion-item lines="none">


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#700 
### Short Description and Why It's Useful
- Modified the existing Webhook functionality to automatically mark orders as approved once payment has been made on Shopify. 
- This will streamline the order approval process and resolve issues encountered in adoc.



### Screenshots of Visual Changes before/after (If There Are Any)
![Screenshot from 2024-04-25 11-24-59](https://github.com/hotwax/job-manager/assets/89250683/eb9262b0-b782-4411-bd5a-bdbdfbf82077)
![Screenshot from 2024-04-25 11-24-09](https://github.com/hotwax/job-manager/assets/89250683/13b55830-31f1-49e1-852e-b8d42894de19)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)