### PR TITLE
Fixed: changing the shopifyConfig now update the webhook(#700)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -231,7 +231,11 @@ const actions: ActionTree<UserState, RootState> = {
    * update current shopify config id
    */
   async setCurrentShopifyConfig({ commit, dispatch, state }, payload) {
-    const shopifyConfig = state.shopifyConfigs.find((configs: any) => configs.shopifyConfigId === payload.shopifyConfigId);
+    let shopifyConfig = {} as any;
+
+    if(payload.shopifyConfigId) {
+      shopifyConfig = state.shopifyConfigs.find((configs: any) => configs.shopifyConfigId === payload.shopifyConfigId);
+    }
     commit(types.USER_CURRENT_SHOPIFY_CONFIG_UPDATED, shopifyConfig ? shopifyConfig : {});
     dispatch('job/clearJobState', null, { root: true });
   },

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -231,11 +231,7 @@ const actions: ActionTree<UserState, RootState> = {
    * update current shopify config id
    */
   async setCurrentShopifyConfig({ commit, dispatch, state }, payload) {
-    let shopifyConfig = payload.shopifyConfig;
-    if(!shopifyConfig) {
-      shopifyConfig = state.shopifyConfigs.find((configs: any) => configs.shopifyConfigId === payload.shopifyConfigId)
-    }
-
+    const shopifyConfig = state.shopifyConfigs.find((configs: any) => configs.shopifyConfigId === payload.shopifyConfigId);
     commit(types.USER_CURRENT_SHOPIFY_CONFIG_UPDATED, shopifyConfig ? shopifyConfig : {});
     dispatch('job/clearJobState', null, { root: true });
   },

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -233,7 +233,7 @@ const actions: ActionTree<UserState, RootState> = {
   async setCurrentShopifyConfig({ commit, dispatch, state }, payload) {
     let shopifyConfig = {} as any;
 
-    if(payload.shopifyConfigId) {
+    if (payload.shopifyConfigId) {
       shopifyConfig = state.shopifyConfigs.find((configs: any) => configs.shopifyConfigId === payload.shopifyConfigId);
     }
     commit(types.USER_CURRENT_SHOPIFY_CONFIG_UPDATED, shopifyConfig ? shopifyConfig : {});

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -9,7 +9,7 @@ import logger from "@/logger";
 
 const actions: ActionTree<WebhookState, RootState> = {
   async fetchWebhooks({ commit }) {
-    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.currentShopifyConfig.shopifyConfigId }).then(resp => {
+    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.currentShopifyConfig }).then(resp => {
       if (resp.status == 200 && resp.data.webhooks?.length > 0 && !hasError(resp)) {
         const webhooks = resp.data.webhooks;
         const topics: any = {}
@@ -17,6 +17,9 @@ const actions: ActionTree<WebhookState, RootState> = {
           topics[webhook.topic] = webhook
         })
         commit(types.WEBHOOK_UPDATED, topics)
+      }
+      else{
+        commit(types.WEBHOOK_UPDATED, []);
       }
     }).catch(err => logger.error(err))
   },

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -9,7 +9,7 @@ import logger from "@/logger";
 
 const actions: ActionTree<WebhookState, RootState> = {
   async fetchWebhooks({ commit }) {
-    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.currentShopifyConfig }).then(resp => {
+    await WebhookService.fetchShopifyWebhooks({ shopifyConfigId: this.state.user.currentShopifyConfig.shopifyConfigId }).then(resp => {
       if (resp.status == 200 && resp.data.webhooks?.length > 0 && !hasError(resp)) {
         const webhooks = resp.data.webhooks;
         const topics: any = {}

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -21,7 +21,10 @@ const actions: ActionTree<WebhookState, RootState> = {
       else{
         commit(types.WEBHOOK_UPDATED, []);
       }
-    }).catch(err => logger.error(err))
+    }).catch (err => {
+       logger.error(err);
+       commit(types.WEBHOOK_UPDATED, []);
+    })
   },
   async unsubscribeWebhook({ dispatch }, payload: any) {
 

--- a/src/store/modules/webhook/actions.ts
+++ b/src/store/modules/webhook/actions.ts
@@ -17,13 +17,12 @@ const actions: ActionTree<WebhookState, RootState> = {
           topics[webhook.topic] = webhook
         })
         commit(types.WEBHOOK_UPDATED, topics)
-      }
-      else{
+      } else {
         commit(types.WEBHOOK_UPDATED, []);
       }
     }).catch (err => {
-       logger.error(err);
-       commit(types.WEBHOOK_UPDATED, []);
+      logger.error(err);
+      commit(types.WEBHOOK_UPDATED, []);
     })
   },
   async unsubscribeWebhook({ dispatch }, payload: any) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#702 
### Short Description and Why It's Useful
- Modify `setCurrentShopifyConfig()` to ensure that the `shopifyConfig` object includes the `shopId` and `name`
- Update the `fetchShopifyWebhooks` service to handle cases where no webhook is subscribed for a specific `shopifyConfig`.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)