### PR TITLE
Fixed: made changes in the frequency code , such that both label and radio button are in sorted position

### DIFF
--- a/src/components/CustomFrequencyModal.vue
+++ b/src/components/CustomFrequencyModal.vue
@@ -20,8 +20,10 @@
     <div v-else>
       <ion-list>
         <ion-radio-group v-model="frequencyId">
+          <!-- Use ion-label to place the label after the radio button -->
           <ion-item :key="customFrequency.tempExprId" v-for="customFrequency in customFrequencies">
-            <ion-radio :value="customFrequency.tempExprId" slot="start">{{ customFrequency.description }}</ion-radio>
+            <ion-radio :value="customFrequency.tempExprId" slot="start"></ion-radio>
+            <ion-label class="radio-label">{{ customFrequency.description }}</ion-label>
           </ion-item>
         </ion-radio-group>
       </ion-list>

--- a/src/components/CustomFrequencyModal.vue
+++ b/src/components/CustomFrequencyModal.vue
@@ -20,7 +20,6 @@
     <div v-else>
       <ion-list>
         <ion-radio-group v-model="frequencyId">
-          <!-- Use ion-label to place the label after the radio button -->
           <ion-item :key="customFrequency.tempExprId" v-for="customFrequency in customFrequencies">
             <ion-radio :value="customFrequency.tempExprId" label-placement="end" justify="start">{{ customFrequency.description }}</ion-radio>
           </ion-item>

--- a/src/components/CustomFrequencyModal.vue
+++ b/src/components/CustomFrequencyModal.vue
@@ -22,8 +22,7 @@
         <ion-radio-group v-model="frequencyId">
           <!-- Use ion-label to place the label after the radio button -->
           <ion-item :key="customFrequency.tempExprId" v-for="customFrequency in customFrequencies">
-            <ion-radio :value="customFrequency.tempExprId" slot="start"></ion-radio>
-            <ion-label class="radio-label">{{ customFrequency.description }}</ion-label>
+            <ion-radio :value="customFrequency.tempExprId" label-placement="end" justify="start">{{ customFrequency.description }}</ion-radio>
           </ion-item>
         </ion-radio-group>
       </ion-list>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#714 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Ensured the ion-radio and ion-label elements are within the ion-item element. The ion-radio element is placed before the ion-label element and assigned the slot="start" attribute to position it at the start of the ion-item.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-07-11 19-46-19](https://github.com/hotwax/job-manager/assets/81156501/d8d19478-e50e-4dad-992b-9e4e01310aa5)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)