### PR TITLE
Fixed: positioning of the ion-radio items label and the circleOutline(#714)

### DIFF
--- a/src/components/CustomFrequencyModal.vue
+++ b/src/components/CustomFrequencyModal.vue
@@ -21,7 +21,7 @@
       <ion-list>
         <ion-radio-group v-model="frequencyId">
           <ion-item :key="customFrequency.tempExprId" v-for="customFrequency in customFrequencies">
-            <ion-radio :value="customFrequency.tempExprId" slot="start">{{ customFrequency.description }}</ion-radio>
+            <ion-radio :value="customFrequency.tempExprId" label-placement="end" justify="start">{{ customFrequency.description }}</ion-radio>
           </ion-item>
         </ion-radio-group>
       </ion-list>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#714 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Ensured that the ion-radio and ion-label elements are placed within the ion-item element.
- The ion-radio element is positioned before the ion-label element and assigned the slot="start" attribute to place it at the start of the ion-item.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)