### PR TITLE
Improved: Added a function to set the ion-badge color based on log status and updated the 'Failed Records' icon properties (#680)

### DIFF
--- a/src/views/DataManagerLogDetails.vue
+++ b/src/views/DataManagerLogDetails.vue
@@ -92,10 +92,10 @@
             <p>{{ translate('Finished') }}</p>
           </ion-label>
 
-          <ion-badge v-if="log.statusId" :color="log.statusId === 'SERVICE_FAILED' ? 'danger' : 'success'">{{ translate(getStatusDesc(log.statusId)) }}</ion-badge>
+          <ion-badge v-if="log.statusId" :color="getLogStatusColor(log.statusId)">{{ translate(getStatusDesc(log.statusId)) }}</ion-badge>
           
           <div class="ion-text-center" lines="none" v-if="log.errorRecordContentId" button @click="downloadErrorRecordFile(log)">
-            <ion-icon slot="start" :icon="cloudDownloadOutline" />
+            <ion-icon slot="icon-only" color="medium" :icon="cloudDownloadOutline" />
             <ion-label>
               <p>{{ translate('Failed records') }}</p>
             </ion-label>
@@ -256,6 +256,19 @@ export default defineComponent ({
         }
       } catch (error) {
         logger.error(error);
+      }
+    },
+    getLogStatusColor(statusId) {
+      if (statusId === 'SERVICE_FINISHED') {
+        return 'success';
+      } else if (statusId === 'SERVICE_RUNNING') {
+        return 'dark';
+      } else if (statusId === 'SERVICE_FAILED') {
+        return 'danger';
+      } else if (statusId === 'SERVICE_PENDING') {
+        return 'medium';
+      } else {
+        return 'medium';
       }
     }
   },


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#680

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a function to set the `ion-badge` color for the log item based on the `statusId`.
- Updated the properties of the `Failed records` ion-icon, such as slot and color.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/b6b62b3c-a451-4c94-aff4-549100ef7e87)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)