### PR TITLE
Improved: Added checks for various cases on the "Learn More" modal(#726)

### DIFF
--- a/src/components/LearnMoreModal.vue
+++ b/src/components/LearnMoreModal.vue
@@ -23,7 +23,7 @@
       </ion-item>
     </div>
 
-    <div class="empty-state" v-else-if="!(askResponse).text">
+    <div class="empty-state" v-else-if="!askResponse.text">
       <ion-item lines="none">
         <p>{{ translate("The job details is not generating, please try again later.") }}</p>
       </ion-item>

--- a/src/components/LearnMoreModal.vue
+++ b/src/components/LearnMoreModal.vue
@@ -23,7 +23,7 @@
       </ion-item>
     </div>
 
-    <div class="empty-state" v-else-if="!Object.keys(askResponse).length">
+    <div class="empty-state" v-else-if="!(askResponse).text">
       <ion-item lines="none">
         <p>{{ translate("The job details is not generating, please try again later.") }}</p>
       </ion-item>
@@ -37,11 +37,11 @@
         </ion-label>
       </ion-item>
 
-      <ion-list>
+      <ion-list v-if="jobSection.length">
         <ion-item lines="none">
           <ion-label>{{ translate("Sources") }}</ion-label>
         </ion-item>
-        <ion-row class="ion-padding" v-for="section in jobSection" :key="section.id">
+        <ion-row class="ion-padding-start" v-for="section in jobSection" :key="section.id">
           <ion-chip outline @click="redirectToDoc(section)">
             <ion-label>{{ section.title }}</ion-label>
             <ion-icon :icon="openOutline" />
@@ -138,7 +138,7 @@ export default defineComponent({
           this.askResponse = resp.data.answer;
           if(this.askResponse) {
             const pageIds = this.askResponse?.sources.map((source: any) => source.page);
-            this.searchQuery(pageIds);
+            pageIds && pageIds.length ? this.searchQuery(pageIds) : this.isGeneratingAnswer = false
           } else {
             this.isGeneratingAnswer = false;
           }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#726 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- If a summary is not present for a job, an empty state will appear on the modal.
- If sources are not present for any reason, the summary may still be visible on the modal.

### Screenshots of Visual Changes before/after (If There Are Any)

![image](https://github.com/user-attachments/assets/c9952de7-3898-4094-90a2-69ffbb304ff9)
![image](https://github.com/user-attachments/assets/dbbb7f23-bc05-4d01-be19-9531b58c48ce)
![Screenshot from 2025-01-09 19-42-54](https://github.com/user-attachments/assets/54e3e027-eeb8-4b89-85ff-57947f9e103e)
![Screenshot from 2025-01-09 19-37-33](https://github.com/user-attachments/assets/37c42c4e-77c0-402c-b7f9-667d28b56ea0)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)