### PR TITLE
Fixed: productStoreId not setting in job param on cloning the job (#793)

### DIFF
--- a/src/components/MaargJobConfiguration.vue
+++ b/src/components/MaargJobConfiguration.vue
@@ -190,7 +190,7 @@ export default defineComponent({
                     }
                     clonedJob.serviceJobParameters.find((parameter: any) => {
                       if(parameter.parameterName === "productStoreIds") {
-                        parameter.paramterValue = this.currentEComStore.productStoreIds
+                        parameter.parameterValue = this.currentEComStore.productStoreId
                         return true;
                       }
                       return false;

--- a/src/components/MaargJobConfiguration.vue
+++ b/src/components/MaargJobConfiguration.vue
@@ -328,7 +328,7 @@ export default defineComponent({
         }
         clonedJob.serviceJobParameters.find((parameter: any) => {
           if(parameter.parameterName === "productStoreIds") {
-            parameter.paramterValue = this.currentEComStore.productStoreIds
+            parameter.parameterValue = this.currentEComStore.productStoreId
             return true;
           }
           return false;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#793

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the issue related to Product store id not setting in job param on cloning the job.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)