### PR TITLE
Fixed: logic for displaying the scheduled job instead of template job for moqui specific jobs(#734)

### DIFF
--- a/src/store/modules/maargJob/actions.ts
+++ b/src/store/modules/maargJob/actions.ts
@@ -43,7 +43,7 @@ const actions: ActionTree<JobState, RootState> = {
             } else {
               // For handling case where we have childs jobs for the productstore independent job
               // We'll give preference to job with parentJobName and then the job without parentJobName
-              if(!maargJobs[job.jobTypeEnumId] || !job.parentJobName) {
+              if(!maargJobs[job.jobTypeEnumId] || job.parentJobName) {
                 maargJobs[job.jobTypeEnumId] = job
               }
             }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#734 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
If a job is not productStore dependent then the job with parentJobName(already scheduled, childJob) will be given the preference to be displayed on the UI


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)