### PR TITLE
Fixed : The Select E-Commerce Store option remains visible even when no shopify shop is associated with the product store.(#784)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -162,6 +162,7 @@
   "New orders": "New orders",
   "New products": "New products",
   "No": "No",
+  "No eCommerce stores connected to this store.": "No eCommerce stores connected to this store.",
   "No frequency found": "No frequency found",
   "No logs found": "No logs found",
   "No jobs have run yet": "No jobs have run yet",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -162,7 +162,7 @@
   "New orders": "New orders",
   "New products": "New products",
   "No": "No",
-  "No eCommerce stores connected to this store.": "No eCommerce stores connected to this store.",
+  "No eCommerce stores connected to": "No eCommerce stores connected to {eCommStore}",
   "No frequency found": "No frequency found",
   "No logs found": "No logs found",
   "No jobs have run yet": "No jobs have run yet",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -75,7 +75,7 @@
           </ion-item>
           <ion-item lines="none" v-else>
             <ion-label>
-              {{ translate(`No eCommerce stores connected to this ${currentEComStore.storeName}`) }}
+              {{ translate(`No eCommerce stores connected to ${currentEComStore.storeName}`) }}
             </ion-label>
           </ion-item>
         </ion-card>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -68,10 +68,13 @@
           <ion-card-content>
             {{ translate('eCommerce stores are directly connected to one Shop Config. If your OMS is connected to multiple eCommerce stores selling the same catalog operating as one Company, you may have multiple Shop Configs for the selected Product Store.') }}
           </ion-card-content>
-          <ion-item lines="none">
+          <ion-item lines="none" v-if="shopifyConfigs.length > 0">
             <ion-select :label="translate('Select eCommerce')" interface="popover" :value="currentShopifyConfig?.shopifyConfigId" @ionChange="setShopifyConfig($event)">
               <ion-select-option v-for="shopifyConfig in shopifyConfigs" :key="shopifyConfig.shopifyConfigId" :value="shopifyConfig.shopifyConfigId" >{{ shopifyConfig.name ? shopifyConfig.name : shopifyConfig.shopifyConfigName }}</ion-select-option>
             </ion-select>
+          </ion-item>
+          <ion-item lines="none" v-else>
+            {{ translate("No eCommerce stores connected to this store.") }}
           </ion-item>
         </ion-card>
       </section>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -75,7 +75,7 @@
           </ion-item>
           <ion-item lines="none" v-else>
             <ion-label>
-              {{ translate(`No eCommerce stores connected to this ${currentEComStore.storeName} store.`) }}
+              {{ translate(`No eCommerce stores connected to this ${currentEComStore.storeName}`) }}
             </ion-label>
           </ion-item>
         </ion-card>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -75,7 +75,7 @@
           </ion-item>
           <ion-item lines="none" v-else>
             <ion-label>
-              {{ translate(`No eCommerce stores connected to ${currentEComStore.storeName}`) }}
+              {{ translate("No eCommerce stores connected to", { eCommStore : currentEComStore.storeName }) }}
             </ion-label>
           </ion-item>
         </ion-card>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -75,7 +75,7 @@
           </ion-item>
           <ion-item lines="none" v-else>
             <ion-label>
-              {{ translate("No eCommerce stores connected to", { eCommStore : currentEComStore.storeName }) }}
+              {{ translate("No eCommerce stores connected to", { eCommStore : currentEComStore.storeName ? currentEComStore.storeName : currentEComStore.productStoreId }) }}
             </ion-label>
           </ion-item>
         </ion-card>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -74,7 +74,9 @@
             </ion-select>
           </ion-item>
           <ion-item lines="none" v-else>
-            {{ translate("No eCommerce stores connected to this store.") }}
+            <ion-label>
+              {{ translate(`No eCommerce stores connected to this ${currentEComStore.storeName} store.`) }}
+            </ion-label>
           </ion-item>
         </ion-card>
       </section>
@@ -89,7 +91,7 @@
 </template>
 
 <script lang="ts">
-import { IonAvatar, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader,IonIcon, IonItem, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar } from '@ionic/vue';
+import { IonAvatar, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader,IonIcon, IonItem, IonLabel, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar } from '@ionic/vue';
 import { defineComponent } from 'vue';
 import { codeWorkingOutline, ellipsisVertical, personCircleOutline, openOutline, saveOutline, timeOutline } from 'ionicons/icons'
 import { mapGetters, useStore } from 'vuex';
@@ -117,7 +119,8 @@ export default defineComponent({
     IonSelectOption,
     IonTitle, 
     IonToolbar,
-    Image
+    Image,
+    IonLabel
   },
   data() {
     return {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#784 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added a fallback text in case when no shopify shop is associated with the product store .

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
<img width="331" height="308" alt="Screenshot from 2025-08-11 11-24-07" src="https://github.com/user-attachments/assets/0e603e9b-e1f4-4c20-839b-cf5146d56917" />

updated UI 
<img width="331" height="308" alt="image" src="https://github.com/user-attachments/assets/60f47954-b858-4256-a134-c29e5d4da5e3" />



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)