### PR TITLE
Remove legacy product flow references

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,7 +68,6 @@
   "Daily": "Daily",
   "Dashoard": "Dashoard",
   "Days": "Days",
-  "Delete products": "Delete products",
   "Disable": "Disable",
   "Disabled": "Disabled",
   "Discard changes": "Discard changes",

--- a/src/services/WebhookService.ts
+++ b/src/services/WebhookService.ts
@@ -27,14 +27,6 @@ const webhookParameters = {
     'topic': 'refunds/create',
     'endpoint': 'returnOrderShopifyWebhook'
   },
-  'NEW_PRODUCTS': {
-    'topic': 'products/create',
-    'endpoint': 'createProductShopifyWebhook'
-  },
-  'DELETE_PRODUCTS': {
-    'topic': 'products/delete',
-    'endpoint': 'deleteProductFromShopify'
-  },
   'BULK_OPERATIONS_FINISH': {
     'topic': 'bulk_operations/finish',
     'endpoint': 'uploadedFileStatusUpdateFromShopify'


### PR DESCRIPTION
Remove unused code related to the old product flow from en.json and WebhookService.ts.
### Related Issues
[oms](https://git.hotwax.co/commerce/oms/-/merge_requests/6166)
[Job Manager](https://github.com/hotwax/job-manager/issues/839)

