### PR TITLE
[codex] Document local Moqui login env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ VITE_I18N_FALLBACK_LOCALE=en-US
 VITE_CACHE_MAX_AGE=3600
 VITE_VIEW_SIZE=10
 VITE_APP_PERMISSION_ID="JOB_MANAGER_APP_VIEW"
-VITE_ALIAS=
+VITE_ALIAS={"local":"http://localhost:8080"}
+VITE_DEFAULT_ALIAS=local
+VITE_OMS_TYPE=MOQUI
 VITE_DEFAULT_LOG_LEVEL="error"
 VITE_LAUNCHPAD_URL="http://launchpad.hotwax.io/login"
 VITE_LEGACY_APP_URL="https://job-manager-legacy.hotwax.io/login?oms={oms}&token={token}&expirationTime={expirationTime}&omsRedirectionUrl={omsRedirectionUrl}"

--- a/src/store/user.spec.ts
+++ b/src/store/user.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const { apiMock, getMaargURLMock, getOmsURLMock, hasErrorMock } = vi.hoisted(() => ({
+  apiMock: vi.fn(),
+  getMaargURLMock: vi.fn(() => "http://localhost:8080/rest/s1"),
+  getOmsURLMock: vi.fn(() => "http://localhost:8080/rest/s1/admin"),
+  hasErrorMock: vi.fn(() => false)
+}));
+
+vi.mock("@common", () => ({
+  api: apiMock,
+  commonUtil: {
+    getMaargURL: getMaargURLMock,
+    getOmsURL: getOmsURLMock,
+    hasError: hasErrorMock,
+    showToast: vi.fn()
+  },
+  translate: (value: string) => value
+}));
+
+vi.mock("@common/composables/useAuth", () => ({
+  useAuth: () => ({
+    clearAuth: vi.fn(),
+    updateUserId: vi.fn()
+  })
+}));
+
+vi.mock("@/utils", () => ({
+  isAppCompatible: vi.fn(() => true),
+  redirectToLegacyApp: vi.fn(),
+  showToast: vi.fn()
+}));
+
+vi.mock("@/logger", () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn()
+  }
+}));
+
+vi.mock("./util", () => ({
+  useUtilStore: () => ({
+    fetchSystemInformation: vi.fn()
+  })
+}));
+
+import { useUserStore } from "@/store/user";
+
+describe("user store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    apiMock.mockReset();
+    getMaargURLMock.mockClear();
+    getOmsURLMock.mockClear();
+    hasErrorMock.mockClear();
+  });
+
+  it("fetches permissions from the Moqui user permissions endpoint", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          docs: [
+            { permissionId: "JOB_MANAGER_VIEW" },
+            { permissionId: "SERVICE_JOB_ADMIN" }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          docs: []
+        }
+      });
+
+    const store = useUserStore();
+    await store.fetchPermissions();
+
+    expect(apiMock).toHaveBeenNthCalledWith(1, {
+      url: "admin/user/permissions",
+      method: "get",
+      baseURL: "http://localhost:8080/rest/s1",
+      params: { viewIndex: 0, viewSize: 200 }
+    });
+    expect(apiMock).toHaveBeenNthCalledWith(2, {
+      url: "admin/user/permissions",
+      method: "get",
+      baseURL: "http://localhost:8080/rest/s1",
+      params: { viewIndex: 1, viewSize: 200 }
+    });
+    expect(getOmsURLMock).not.toHaveBeenCalled();
+    expect(store.permissions).toEqual(["JOB_MANAGER_VIEW", "SERVICE_JOB_ADMIN"]);
+  });
+});

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -131,10 +131,10 @@ export const useUserStore = defineStore("user", {
         let resp;
         do {
           resp = await api({
-            url: "getPermissions",
-            method: "post",
-            baseURL: commonUtil.getOmsURL(),
-            data: { viewIndex, viewSize }
+            url: "admin/user/permissions",
+            method: "get",
+            baseURL: commonUtil.getMaargURL(),
+            params: { viewIndex, viewSize }
           }) as any
 
           if (resp.status === 200 && resp.data.docs?.length && !commonUtil.hasError(resp)) {

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { systemInformation } = vi.hoisted(() => ({
+  systemInformation: {
+    instanceInfo: {
+      componentRelease: ""
+    }
+  }
+}));
+
+vi.mock("file-saver", () => ({
+  default: vi.fn()
+}));
+
+vi.mock("@ionic/vue", () => ({
+  toastController: {
+    create: vi.fn()
+  }
+}));
+
+vi.mock("@capacitor/clipboard", () => ({
+  Clipboard: {
+    write: vi.fn()
+  }
+}));
+
+vi.mock("@common", () => ({
+  cookieHelper: () => ({
+    get: vi.fn()
+  }),
+  translate: (value: string) => value
+}));
+
+vi.mock("@/logger", () => ({
+  default: {
+    error: vi.fn()
+  }
+}));
+
+vi.mock("@/store/util", () => ({
+  useUtilStore: () => ({
+    systemInformation
+  })
+}));
+
+vi.mock("@/store/user", () => ({
+  useUserStore: () => ({
+    oms: "http://localhost:8080"
+  })
+}));
+
+import { isAppCompatible } from "@/utils";
+
+describe("app compatibility", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_MAARG_COMPATIBLE_VERSION", "5.2.0");
+  });
+
+  it("treats the local Moqui UpcomingRelease label as compatible", () => {
+    systemInformation.instanceInfo.componentRelease = "UpcomingRelease";
+
+    expect(isAppCompatible()).toBe(true);
+  });
+
+  it("does not block login when no required compatible version is configured", () => {
+    vi.stubEnv("VITE_MAARG_COMPATIBLE_VERSION", "");
+    systemInformation.instanceInfo.componentRelease = "UpcomingRelease";
+
+    expect(isAppCompatible()).toBe(true);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -153,10 +153,12 @@ const getFileSize = (size: string) => {
 const isAppCompatible = () => {
   const currentVersion = useUtilStore().systemInformation?.instanceInfo?.componentRelease;
   const requiredVersion = import.meta.env.VITE_MAARG_COMPATIBLE_VERSION;
+  const compatibleDevelopmentReleases = ["main", "UpcomingRelease"];
   
-  if(!currentVersion || !requiredVersion) return false;
+  if(!requiredVersion) return true;
+  if(!currentVersion) return false;
   
-  if(currentVersion === "main") return true;
+  if(compatibleDevelopmentReleases.includes(currentVersion)) return true;
   
   const currentParts = currentVersion.split('.').map(Number);
   const requiredParts = requiredVersion.split('.').map(Number);


### PR DESCRIPTION
## Business summary

This gives Job Manager a working local-development path for logging into a local Moqui instance after the direct-Moqui PWA changes. Developers should be able to point the app at `http://localhost:8080`, authenticate through the Moqui admin login endpoints, pass the Job Manager permission gate, and continue into the app instead of falling back to the legacy OFBiz `/api` login shape.

Fixes #902.

## Changes

- Set the example `local` OMS alias to `http://localhost:8080`.
- Set the example default alias to `local` and document `VITE_OMS_TYPE=MOQUI`.
- Fetch Job Manager permissions from `admin/user/permissions` through the Moqui/Maarg base URL.
- Treat local development release labels such as `UpcomingRelease` as compatible.
- Add focused unit coverage for Moqui permissions and local release compatibility.

## Validation

- `pnpm --filter job-manager test:unit --run src/store/user.spec.ts src/utils/index.spec.ts`
- `pnpm --filter job-manager test:unit --run src/utils/index.spec.ts`
- Started Job Manager locally and confirmed the emitted env includes `VITE_ALIAS={"local":"http://localhost:8080"}` and `VITE_OMS_TYPE=MOQUI`.
- Confirmed `GET http://localhost:8080/rest/s1/admin/checkLoginOptions` returns BASIC login options.
