### PR TITLE
[codex] Fix Moqui permission loading during login

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import Catalog from '@/views/Catalog.vue'
+import Catalog from '@/views/catalog.vue'
 import Settings from "@/views/Settings.vue"
 import FileHistory from "@/views/FileHistory.vue"
 import FileDetail from "@/views/FileDetail.vue"

--- a/src/store/user.spec.ts
+++ b/src/store/user.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const { apiMock, isMoquiMock, showToastMock } = vi.hoisted(() => ({
+  apiMock: vi.fn(),
+  isMoquiMock: vi.fn(),
+  showToastMock: vi.fn()
+}));
+
+vi.mock("@common", () => ({
+  api: apiMock,
+  commonUtil: {
+    getOmsURL: () => "http://localhost:8080/rest/s1/",
+    hasError: () => false,
+    isMoqui: isMoquiMock,
+    showToast: showToastMock
+  },
+  translate: (value: string) => value
+}));
+
+vi.mock("@/utils", () => ({
+  isAppCompatible: () => true,
+  redirectToLegacyApp: vi.fn(),
+  showToast: showToastMock
+}));
+
+vi.mock("@/logger", () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn()
+  }
+}));
+
+vi.mock("@common/composables/useAuth", () => ({
+  useAuth: () => ({
+    updateUserId: vi.fn(),
+    clearAuth: vi.fn()
+  })
+}));
+
+import { useUserStore } from "@/store/user";
+
+describe("user store permissions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    apiMock.mockReset();
+    isMoquiMock.mockReturnValue(true);
+    showToastMock.mockReset();
+  });
+
+  it("loads permissions from the Moqui admin user permissions endpoint", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          docs: [
+            { permissionId: "JOB_MANAGER_APP_VIEW" },
+            { permissionId: "SERVICE_JOB_VIEW" }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          docs: []
+        }
+      });
+
+    const store = useUserStore();
+    await store.fetchPermissions();
+
+    expect(apiMock).toHaveBeenNthCalledWith(1, {
+      url: "admin/user/permissions",
+      method: "GET",
+      baseURL: "http://localhost:8080/rest/s1/",
+      params: { viewIndex: 0, viewSize: 200 }
+    });
+    expect(store.permissions).toEqual(["JOB_MANAGER_APP_VIEW", "SERVICE_JOB_VIEW"]);
+  });
+
+  it("keeps the legacy permissions endpoint for non-Moqui deployments", async () => {
+    isMoquiMock.mockReturnValue(false);
+    apiMock.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        docs: []
+      }
+    });
+
+    const store = useUserStore();
+    await store.fetchPermissions();
+
+    expect(apiMock).toHaveBeenCalledWith({
+      url: "getPermissions",
+      method: "post",
+      baseURL: "http://localhost:8080/rest/s1/",
+      data: { viewIndex: 0, viewSize: 200 }
+    });
+  });
+});

--- a/src/store/user.spec.ts
+++ b/src/store/user.spec.ts
@@ -92,7 +92,7 @@ describe("user store permissions", () => {
 
     expect(apiMock).toHaveBeenCalledWith({
       url: "getPermissions",
-      method: "post",
+      method: "POST",
       baseURL: "http://localhost:8080/rest/s1/",
       data: { viewIndex: 0, viewSize: 200 }
     });

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -130,11 +130,12 @@ export const useUserStore = defineStore("user", {
       try {
         let resp;
         do {
+          const isMoqui = commonUtil.isMoqui?.();
           resp = await api({
-            url: "getPermissions",
-            method: "post",
+            url: isMoqui ? "admin/user/permissions" : "getPermissions",
+            method: isMoqui ? "GET" : "post",
             baseURL: commonUtil.getOmsURL(),
-            data: { viewIndex, viewSize }
+            [isMoqui ? "params" : "data"]: { viewIndex, viewSize }
           }) as any
 
           if (resp.status === 200 && resp.data.docs?.length && !commonUtil.hasError(resp)) {

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -129,11 +129,11 @@ export const useUserStore = defineStore("user", {
 
       try {
         let resp;
+        const isMoqui = commonUtil.isMoqui?.();
         do {
-          const isMoqui = commonUtil.isMoqui?.();
           resp = await api({
             url: isMoqui ? "admin/user/permissions" : "getPermissions",
-            method: isMoqui ? "GET" : "post",
+            method: isMoqui ? "GET" : "POST",
             baseURL: commonUtil.getOmsURL(),
             [isMoqui ? "params" : "data"]: { viewIndex, viewSize }
           }) as any

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("file-saver", () => ({
+  default: vi.fn()
+}));
+
+vi.mock("@ionic/vue", () => ({
+  toastController: {
+    create: vi.fn()
+  }
+}));
+
+vi.mock("@capacitor/clipboard", () => ({
+  Clipboard: {
+    write: vi.fn()
+  }
+}));
+
+vi.mock("@common", () => ({
+  cookieHelper: () => ({
+    get: vi.fn()
+  }),
+  translate: (value: string) => value
+}));
+
+vi.mock("@/logger", () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn()
+  }
+}));
+
+import { useUtilStore } from "@/store/util";
+import { isAppCompatible } from "@/utils";
+
+describe("app compatibility utilities", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    import.meta.env.VITE_MAARG_COMPATIBLE_VERSION = undefined;
+  });
+
+  it("treats a missing required maarg version as compatibility check disabled", () => {
+    useUtilStore().systemInformation = {
+      instanceInfo: {
+        componentRelease: "5.1.0"
+      }
+    };
+
+    expect(isAppCompatible()).toBe(true);
+  });
+
+  it("rejects versions below the configured required maarg version", () => {
+    import.meta.env.VITE_MAARG_COMPATIBLE_VERSION = "5.2.0";
+    useUtilStore().systemInformation = {
+      instanceInfo: {
+        componentRelease: "5.1.0"
+      }
+    };
+
+    expect(isAppCompatible()).toBe(false);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -154,7 +154,8 @@ const isAppCompatible = () => {
   const currentVersion = useUtilStore().systemInformation?.instanceInfo?.componentRelease;
   const requiredVersion = import.meta.env.VITE_MAARG_COMPATIBLE_VERSION;
   
-  if(!currentVersion || !requiredVersion) return false;
+  if(!requiredVersion) return true;
+  if(!currentVersion) return false;
   
   if(currentVersion === "main") return true;
   
@@ -164,10 +165,10 @@ const isAppCompatible = () => {
   for(let i = 0; i < 3; i++) {
     const part1 = currentParts[i] || 0;
     const part2 = requiredParts[i] || 0;
-    if(part1 >= part2) return true;
+    if(part1 > part2) return true;
     if(part1 < part2) return false;
   }
-  return false;
+  return true;
 }
 
 const redirectToLegacyApp = () => {
@@ -176,6 +177,10 @@ const redirectToLegacyApp = () => {
   const expirationTime = cookieHelper().get("expirationTime")!
   const maarg = decodeURIComponent(cookieHelper().get("maarg")!)
   const link = import.meta.env.VITE_LEGACY_APP_URL
+  if(!link) {
+    logger.warn("Legacy app URL is not configured; skipping legacy redirect")
+    return;
+  }
   window.location.href = link.replace("{oms}", oms).replace("{token}", token).replace("{expirationTime}", expirationTime).replace("{omsRedirectionUrl}", maarg)
 }
 


### PR DESCRIPTION
## Business summary
Job Manager users on Moqui-backed environments could enter valid credentials but still land in a login failure state because post-login setup used backend/env assumptions that do not hold for the local Moqui dev flow. This PR keeps the login flow aligned with the active backend contract and verifies the rendered credential login path reaches the catalog screen.

Closes #906

## What changed
- Route Moqui permission loads to `GET admin/user/permissions` with pagination query params.
- Preserve the legacy `POST getPermissions` call for non-Moqui deployments.
- Fix the catalog route import casing so the Vite dev app can boot.
- Treat missing `VITE_MAARG_COMPATIBLE_VERSION` as an unconfigured compatibility check instead of forcing legacy redirect.
- Fix semantic version comparison and guard missing `VITE_LEGACY_APP_URL` from throwing during post-login.
- Add focused tests for permission endpoint selection and compatibility behavior.

## Root cause
The credentials step was already using Moqui-aware auth, but `fetchPermissions()` still used the legacy root `getPermissions` endpoint. Runtime validation also showed the dev server was blocked by a route import case mismatch and local `.env.local` omitted compatibility/legacy redirect variables, causing post-login to throw after auth succeeded.

## Validation
- `pnpm --filter job-manager test:unit src/utils/index.spec.ts src/store/user.spec.ts --run`
- `pnpm --filter job-manager build`
- Rendered login smoke test on local Moqui: `http://127.0.0.1:8115/login` -> select local OMS -> submit local dev credentials -> landed on `/catalog` with Job catalog visible.
- Existing saved-session smoke test on `http://[::1]:8105/login` also lands on `/catalog`.

## Notes
- `pnpm --filter job-manager test:unit --run` was not used as the passing gate because existing `jobs.spec.ts` / `systemMessage.spec.ts` baseline issues are unrelated to this change.