### PR TITLE
Add copy button in Message Detail Page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,7 @@
   "Consume Service": "Consume Service",
   "Consumed": "Consumed",
   "Consumed messages are read-only in this mock implementation.": "Consumed messages are read-only in this mock implementation.",
+  "Copy": "Copy",
   "Copied": "Copied",
   "Create": "Create",
   "Create Job": "Create Job",

--- a/src/views/SystemMessageDetailView.vue
+++ b/src/views/SystemMessageDetailView.vue
@@ -246,29 +246,40 @@
                 </ion-item>
               </template>
 
-              <ion-item-divider color="light">
-                <ion-label>{{ translate("Message Content") }}</ion-label>
-                <div slot="end" class="content-actions">
-                  <ion-button
-                    v-if="downloadableFilePath && !isEditing"
-                    fill="clear"
-                    size="small"
-                    @click="downloadLinkedFile"
-                  >
-                    {{ translate("Download File") }}
-                    <ion-icon slot="start" :icon="downloadOutline" />
-                  </ion-button>
-                  <ion-button
-                    v-if="isEditable && !isEditing"
-                    fill="clear"
-                    size="small"
-                    @click="isEditing = true"
-                  >
-                    {{ translate("Edit Content") }}
-                    <ion-icon slot="start" :icon="addCircleOutline" />
-                  </ion-button>
-                </div>
-              </ion-item-divider>
+         <ion-item-divider color="light">
+           <ion-label>{{ translate("Message Content") }}</ion-label>
+           <div slot="end" class="content-actions">
+             <ion-button
+               v-if="downloadableFilePath && !isEditing"
+               fill="clear"
+               size="small"
+               @click="downloadLinkedFile"
+             >
+               {{ translate("Download File") }}
+               <ion-icon slot="start" :icon="downloadOutline" />
+             </ion-button>
+
+             <ion-button
+               v-if="formattedContent && !isEditing"
+               fill="clear"
+               size="small"
+               @click="commonUtil.copyToClipboard(message?.messageText)"
+             >
+               {{ translate("Copy") }}
+               <ion-icon slot="start" :icon="copyOutline" />
+             </ion-button>
+
+             <ion-button
+               v-if="isEditable && !isEditing"
+               fill="clear"
+               size="small"
+               @click="isEditing = true"
+             >
+               {{ translate("Edit Content") }}
+               <ion-icon slot="start" :icon="addCircleOutline" />
+             </ion-button>
+           </div>
+         </ion-item-divider>
 
               <div class="content-container">
                 <ion-item v-if="downloadableFilePath && !isEditing" lines="none" class="detected-file-path">
@@ -398,6 +409,7 @@ import {
   chevronUpOutline,
   checkmarkCircleOutline,
   documentAttachOutline,
+  copyOutline,
   downloadOutline,
   globeOutline,
   hourglassOutline,

--- a/src/views/SystemMessageDetailView.vue
+++ b/src/views/SystemMessageDetailView.vue
@@ -264,8 +264,8 @@
                     size="small"
                     @click="commonUtil.copyToClipboard(message?.messageText)"
                   >
-                   {{ translate("Copy") }}
-                   <ion-icon slot="start" :icon="copyOutline" />
+                    {{ translate("Copy") }}
+                    <ion-icon slot="start" :icon="copyOutline" />
                   </ion-button>
                   <ion-button
                     v-if="isEditable && !isEditing"

--- a/src/views/SystemMessageDetailView.vue
+++ b/src/views/SystemMessageDetailView.vue
@@ -246,40 +246,38 @@
                 </ion-item>
               </template>
 
-         <ion-item-divider color="light">
-           <ion-label>{{ translate("Message Content") }}</ion-label>
-           <div slot="end" class="content-actions">
-             <ion-button
-               v-if="downloadableFilePath && !isEditing"
-               fill="clear"
-               size="small"
-               @click="downloadLinkedFile"
-             >
-               {{ translate("Download File") }}
-               <ion-icon slot="start" :icon="downloadOutline" />
-             </ion-button>
-
-             <ion-button
-               v-if="formattedContent && !isEditing"
-               fill="clear"
-               size="small"
-               @click="commonUtil.copyToClipboard(message?.messageText)"
-             >
-               {{ translate("Copy") }}
-               <ion-icon slot="start" :icon="copyOutline" />
-             </ion-button>
-
-             <ion-button
-               v-if="isEditable && !isEditing"
-               fill="clear"
-               size="small"
-               @click="isEditing = true"
-             >
-               {{ translate("Edit Content") }}
-               <ion-icon slot="start" :icon="addCircleOutline" />
-             </ion-button>
-           </div>
-         </ion-item-divider>
+              <ion-item-divider color="light">
+                <ion-label>{{ translate("Message Content") }}</ion-label>
+                <div slot="end" class="content-actions">
+                  <ion-button
+                    v-if="downloadableFilePath && !isEditing"
+                    fill="clear"
+                    size="small"
+                    @click="downloadLinkedFile"
+                  >
+                    {{ translate("Download File") }}
+                    <ion-icon slot="start" :icon="downloadOutline" />
+                  </ion-button>
+                  <ion-button
+                    v-if="formattedContent && !isEditing"
+                    fill="clear"
+                    size="small"
+                    @click="commonUtil.copyToClipboard(message?.messageText)"
+                  >
+                   {{ translate("Copy") }}
+                   <ion-icon slot="start" :icon="copyOutline" />
+                  </ion-button>
+                  <ion-button
+                    v-if="isEditable && !isEditing"
+                    fill="clear"
+                    size="small"
+                    @click="isEditing = true"
+                  >
+                    {{ translate("Edit Content") }}
+                    <ion-icon slot="start" :icon="addCircleOutline" />
+                  </ion-button>
+                </div>
+              </ion-item-divider>
 
               <div class="content-container">
                 <ion-item v-if="downloadableFilePath && !isEditing" lines="none" class="detected-file-path">
@@ -419,7 +417,7 @@ import {
   playOutline,
   syncOutline,
   timeOutline,
-  warningOutline
+  warningOutline,
 } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import router from "../router";

--- a/src/views/SystemMessageDetailView.vue
+++ b/src/views/SystemMessageDetailView.vue
@@ -417,7 +417,7 @@ import {
   playOutline,
   syncOutline,
   timeOutline,
-  warningOutline,
+  warningOutline
 } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import router from "../router";

--- a/src/views/SystemMessageDetailView.vue
+++ b/src/views/SystemMessageDetailView.vue
@@ -262,7 +262,7 @@
                     v-if="formattedContent && !isEditing"
                     fill="clear"
                     size="small"
-                    @click="commonUtil.copyToClipboard(message?.messageText)"
+                    @click="commonUtil.copyToClipboard(formattedContent)"
                   >
                     {{ translate("Copy") }}
                     <ion-icon slot="start" :icon="copyOutline" />
@@ -406,8 +406,8 @@ import {
   chevronForwardOutline,
   chevronUpOutline,
   checkmarkCircleOutline,
-  documentAttachOutline,
   copyOutline,
+  documentAttachOutline,
   downloadOutline,
   globeOutline,
   hourglassOutline,


### PR DESCRIPTION
### Related Issues
Enhancement Request: Add Copy Button in Message Detail #914 

#

### Short Description 

Added a Copy button in the System Message Detail view to allow users to quickly copy message content to the clipboard.

This enhancement improves usability by eliminating the need to manually select and copy text, making it easier to reuse, inspect, and share message content.


### Screenshots of Visual Changes before/after 

Before 

<img width="807" height="157" alt="Screenshot from 2026-06-10 10-26-29" src="https://github.com/user-attachments/assets/2ea8e12c-8f21-43ce-9b77-b12cadd0d7da" />


After

<img width="790" height="147" alt="Screenshot from 2026-06-11 14-30-42" src="https://github.com/user-attachments/assets/82657bca-ccdb-42b0-a768-4e2b40311978" />
