### PR TITLE
Added configurable Record limit in Monitor and Remote Systems tab

### DIFF
--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -100,7 +100,7 @@
         <div class="pagination">
           <div class="limit-container">
             <ion-select
-              :label="translate('Limit')"
+              :label="translate('pageSize')"
               label-placement="start"
               interface="popover"
               :value="pageSize"
@@ -158,7 +158,7 @@ import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useUtilStore } from "@/store/util";
 
-const pageSize = ref(25);
+const pageSize = ref(20);
 
 const store = useSystemMessageStore();
 const utilStore = useUtilStore();

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -98,13 +98,31 @@
         </ion-card>
 
         <div class="pagination">
-          <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
-            {{ translate("Previous") }}
-          </ion-button>
-          <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
-          <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
-            {{ translate("Next") }}
-          </ion-button>
+          <div class="limit-container">
+            <ion-select
+              :label="translate('Limit')"
+              label-placement="start"
+              interface="popover"
+              :value="pageSize"
+              @ionChange="pageSize = $event.detail.value"
+            >
+              <ion-select-option :value="10">10</ion-select-option>
+              <ion-select-option :value="20">20</ion-select-option>
+              <ion-select-option :value="50">50</ion-select-option>
+              <ion-select-option :value="100">100</ion-select-option>
+              <ion-select-option :value="200">200</ion-select-option>
+              <ion-select-option :value="500">500</ion-select-option>
+            </ion-select>
+          </div>
+          <div class="pagination-buttons">
+            <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
+              {{ translate("Previous") }}
+            </ion-button>
+            <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
+            <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
+              {{ translate("Next") }}
+            </ion-button>
+          </div>
         </div>
         <SystemMessageList
           :messages="messages"
@@ -140,7 +158,7 @@ import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useUtilStore } from "@/store/util";
 
-const PAGE_SIZE = 25;
+const pageSize = ref(25);
 
 const store = useSystemMessageStore();
 const utilStore = useUtilStore();
@@ -157,7 +175,7 @@ const types = computed(() => store.getSystemMessageTypes);
 const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
-const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const pageCount = computed(() => Math.max(Math.ceil(total.value / pageSize.value), 1));
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -167,7 +185,7 @@ const filteredTypes = computed(() => {
 const loadMessages = async () => {
   const payload = {
     pageIndex: pageIndex.value,
-    pageSize: PAGE_SIZE,
+    pageSize: pageSize.value,
   } as Record<string, any>
 
   if(queryString.value.trim()) {
@@ -214,9 +232,12 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
-watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId], async () => {
-  resetToFirstPage();
-  await loadMessages();
+watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId, pageSize], async () => {
+  if (pageIndex.value !== 0) {
+    pageIndex.value = 0;
+  } else {
+    await loadMessages();
+  }
 });
 
 watch(pageIndex, loadMessages);
@@ -248,9 +269,21 @@ onIonViewWillEnter(async () => {
 
 .pagination {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   gap: 12px;
   padding: 16px;
+}
+
+.pagination-buttons {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.limit-container {
+  display: flex;
+  align-items: center;
+  max-width: 150px;
 }
 </style>

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -18,78 +18,40 @@
 
         <ion-card>
           <ion-card-content>
-            <ion-searchbar
-              :value="queryString"
-              @ionInput="handleQueryInput"
-              :debounce="300"
-              :placeholder="translate('Search by message or parent type')"
-            />
+            <ion-searchbar :value="queryString" @ionInput="handleQueryInput" :debounce="300"
+              :placeholder="translate('Search by message or parent type')" />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatusId"
-                @ionChange="selectedStatusId = $event.detail.value"
-              >
+              <ion-select :label="translate('Status')" label-placement="stacked" interface="popover"
+                :value="selectedStatusId" @ionChange="selectedStatusId = $event.detail.value">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="status in statuses"
-                  :key="status.statusId"
-                  :value="status.statusId"
-                >
+                <ion-select-option v-for="status in statuses" :key="status.statusId" :value="status.statusId">
                   {{ status.description }}
                 </ion-select-option>
               </ion-select>
 
-              <ion-select
-                :label="translate('Parent Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedParentTypeId"
-                @ionChange="handleParentTypeChange($event)"
-              >
+              <ion-select :label="translate('Parent Type')" label-placement="stacked" interface="popover"
+                :value="selectedParentTypeId" @ionChange="handleParentTypeChange($event)">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="parent in parentTypes"
-                  :key="parent.id"
-                  :value="parent.id"
-                >
+                <ion-select-option v-for="parent in parentTypes" :key="parent.id" :value="parent.id">
                   {{ parent.description }}
                 </ion-select-option>
               </ion-select>
 
-              <ion-select
-                :label="translate('Message Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedTypeId"
-                @ionChange="selectedTypeId = $event.detail.value"
-              >
+              <ion-select :label="translate('Message Type')" label-placement="stacked" interface="popover"
+                :value="selectedTypeId" @ionChange="selectedTypeId = $event.detail.value">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="type in filteredTypes"
-                  :key="type.systemMessageTypeId"
-                  :value="type.systemMessageTypeId"
-                >
+                <ion-select-option v-for="type in filteredTypes" :key="type.systemMessageTypeId"
+                  :value="type.systemMessageTypeId">
                   {{ type.description || type.systemMessageTypeId }}
                 </ion-select-option>
               </ion-select>
 
-              <ion-select
-                :label="translate('Remote System')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedRemoteId"
-                @ionChange="selectedRemoteId = $event.detail.value"
-              >
+              <ion-select :label="translate('Remote System')" label-placement="stacked" interface="popover"
+                :value="selectedRemoteId" @ionChange="selectedRemoteId = $event.detail.value">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="remote in remotes"
-                  :key="remote.systemMessageRemoteId"
-                  :value="remote.systemMessageRemoteId"
-                >
+                <ion-select-option v-for="remote in remotes" :key="remote.systemMessageRemoteId"
+                  :value="remote.systemMessageRemoteId">
                   {{ remote.description || remote.systemMessageRemoteId }}
                 </ion-select-option>
               </ion-select>
@@ -98,14 +60,9 @@
         </ion-card>
 
         <div class="pagination">
-          <div class="limit-container">
-            <ion-select
-              :label="translate('pageSize')"
-              label-placement="start"
-              interface="popover"
-              :value="pageSize"
-              @ionChange="pageSize = $event.detail.value"
-            >
+          <!-- <div class="pagination-buttons"> -->
+            <ion-select :label="translate('pageSize')" label-placement="start" interface="popover" :value="pageSize"
+              @ionChange="pageSize = $event.detail.value">
               <ion-select-option :value="10">10</ion-select-option>
               <ion-select-option :value="20">20</ion-select-option>
               <ion-select-option :value="50">50</ion-select-option>
@@ -113,7 +70,7 @@
               <ion-select-option :value="200">200</ion-select-option>
               <ion-select-option :value="500">500</ion-select-option>
             </ion-select>
-          </div>
+          <!-- </div> -->
           <div class="pagination-buttons">
             <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
               {{ translate("Previous") }}
@@ -124,10 +81,8 @@
             </ion-button>
           </div>
         </div>
-        <SystemMessageList
-          :messages="messages"
-          :empty-message="translate('No system messages found for the selected filters.')"
-        />
+        <SystemMessageList :messages="messages"
+          :empty-message="translate('No system messages found for the selected filters.')" />
       </main>
     </ion-content>
   </ion-page>
@@ -188,23 +143,23 @@ const loadMessages = async () => {
     pageSize: pageSize.value,
   } as Record<string, any>
 
-  if(queryString.value.trim()) {
+  if (queryString.value.trim()) {
     payload["queryString"] = queryString.value.trim()
   }
 
-  if(selectedStatusId.value) {
+  if (selectedStatusId.value) {
     payload["statusId"] = selectedStatusId.value
   }
 
-  if(selectedTypeId.value) {
+  if (selectedTypeId.value) {
     payload["systemMessageTypeId"] = selectedTypeId.value
   }
 
-  if(selectedParentTypeId.value) {
+  if (selectedParentTypeId.value) {
     payload["parentTypeId"] = selectedParentTypeId.value
   }
 
-  if(selectedRemoteId.value) {
+  if (selectedRemoteId.value) {
     payload["systemMessageRemoteId"] = selectedRemoteId.value
   }
 
@@ -267,23 +222,22 @@ onIonViewWillEnter(async () => {
   flex-wrap: wrap;
 }
 
+
 .pagination {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  padding: 16px;
+  gap: 10px;
+}
+
+.paginatio ion-select
+{
+  max-width: 150px;
 }
 
 .pagination-buttons {
   display: flex;
   align-items: center;
-  gap: 12px;
-}
-
-.limit-container {
-  display: flex;
-  align-items: center;
-  max-width: 150px;
+  gap: 10px;
 }
 </style>

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -14,16 +14,12 @@
         <div class="header">
           <div class="title">
             <h1>{{ form.systemMessageRemoteId.value || translate("New Remote System") }}</h1>
-            <p>{{ form.description.value || translate("Configure remote system connectivity and inspect related messages.") }}</p>
+            <p>{{ form.description.value || translate("Configure remote system connectivity and inspect related
+              messages.") }}</p>
           </div>
           <div class="header-actions">
             <ion-button fill="outline" @click="saveRemote">{{ translate("Save") }}</ion-button>
-            <ion-button
-              v-if="!isCreateMode"
-              color="danger"
-              fill="outline"
-              @click="deleteRemote"
-            >
+            <ion-button v-if="!isCreateMode" color="danger" fill="outline" @click="deleteRemote">
               {{ translate("Delete") }}
             </ion-button>
           </div>
@@ -36,25 +32,13 @@
           <ion-card-content>
             <div class="form-grid">
               <template v-for="[key, field] of Object.entries(form)" :key="key">
-                <ion-textarea
-                  v-if="field.type === 'textarea'"
-                  :label="translate(field.label)"
-                  label-placement="stacked"
-                  fill="outline"
-                  auto-grow
-                  :value="field.value || ''"
-                  @ionInput="updateField(key, $event.detail.value || '')"
-                />
-                <ion-input
-                  v-else
-                  :type="field.type === 'password' ? 'password' : 'text'"
-                  :label="translate(field.label)"
-                  label-placement="stacked"
-                  fill="outline"
-                  :readonly="!isCreateMode && key === 'systemMessageRemoteId'"
-                  :value="field.value || ''"
-                  @ionInput="updateField(key, $event.detail.value || '')"
-                />
+                <ion-textarea v-if="field.type === 'textarea'" :label="translate(field.label)" label-placement="stacked"
+                  fill="outline" auto-grow :value="field.value || ''"
+                  @ionInput="updateField(key, $event.detail.value || '')" />
+                <ion-input v-else :type="field.type === 'password' ? 'password' : 'text'"
+                  :label="translate(field.label)" label-placement="stacked" fill="outline"
+                  :readonly="!isCreateMode && key === 'systemMessageRemoteId'" :value="field.value || ''"
+                  @ionInput="updateField(key, $event.detail.value || '')" />
               </template>
             </div>
           </ion-card-content>
@@ -67,25 +51,12 @@
             </ion-card-header>
             <ion-card-content>
               <div class="filter-grid">
-                <ion-searchbar
-                  :value="queryString"
-                  @ionInput="queryString = $event.detail.value || ''"
-                  :debounce="300"
-                  :placeholder="translate('Search messages by id')"
-                />
-                <ion-select
-                  :label="translate('Status')"
-                  label-placement="stacked"
-                  interface="popover"
-                  :value="selectedStatusId"
-                  @ionChange="selectedStatusId = $event.detail.value"
-                >
+                <ion-searchbar :value="queryString" @ionInput="queryString = $event.detail.value || ''" :debounce="300"
+                  :placeholder="translate('Search messages by id')" />
+                <ion-select :label="translate('Status')" label-placement="stacked" interface="popover"
+                  :value="selectedStatusId" @ionChange="selectedStatusId = $event.detail.value">
                   <ion-select-option value="">{{ translate("All statuses") }}</ion-select-option>
-                  <ion-select-option
-                    v-for="status in statuses"
-                    :key="status.statusId"
-                    :value="status.statusId"
-                  >
+                  <ion-select-option v-for="status in statuses" :key="status.statusId" :value="status.statusId">
                     {{ status.description }}
                   </ion-select-option>
                 </ion-select>
@@ -93,13 +64,8 @@
 
               <div class="pagination">
                 <div class="limit-container">
-                  <ion-select
-                    :label="translate('pageSize')"
-                    label-placement="start"
-                    interface="popover"
-                    :value="pageSize"
-                    @ionChange="pageSize = $event.detail.value"
-                  >
+                  <ion-select :label="translate('Page Size')" label-placement="start" interface="popover"
+                    :value="pageSize" @ionChange="pageSize = $event.detail.value">
                     <ion-select-option :value="10">10</ion-select-option>
                     <ion-select-option :value="20">20</ion-select-option>
                     <ion-select-option :value="50">50</ion-select-option>
@@ -113,17 +79,15 @@
                     <ion-icon :icon="caretBackOutline" />
                   </ion-button>
                   <ion-note color="medium">{{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
-                  <ion-button fill="clear" slot="icon-only" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
+                  <ion-button fill="clear" slot="icon-only" :disabled="pageIndex >= pageCount - 1"
+                    @click="goToNextPage">
                     <ion-icon :icon="caretForwardOutline" />
                   </ion-button>
                 </div>
               </div>
 
-              <SystemMessageList
-                :messages="relatedMessages"
-                :show-remote="false"
-                :empty-message="translate('No related messages found.')"
-              />
+              <SystemMessageList :messages="relatedMessages" :show-remote="false"
+                :empty-message="translate('No related messages found.')" />
             </ion-card-content>
           </ion-card>
         </section>
@@ -241,7 +205,7 @@ const saveRemote = async () => {
 
   // TODO: check do we need this, as the form fields will always be a string
   const payload = Object.entries(form).reduce((params: Record<string, any>, [key, field]) => {
-    if(field.value !== null || field.value !== undefined) {
+    if (field.value !== null || field.value !== undefined) {
       params[key] = field.value
     }
     return params

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -92,13 +92,31 @@
               </div>
 
               <div class="pagination">
-                <ion-button fill="clear" slot="icon-only" :disabled="pageIndex === 0" @click="goToPreviousPage">
-                  <ion-icon :icon="caretBackOutline" />
-                </ion-button>
-                <ion-note color="medium">{{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
-                <ion-button fill="clear" slot="icon-only" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
-                  <ion-icon :icon="caretForwardOutline" />
-                </ion-button>
+                <div class="limit-container">
+                  <ion-select
+                    :label="translate('Limit')"
+                    label-placement="start"
+                    interface="popover"
+                    :value="pageSize"
+                    @ionChange="pageSize = $event.detail.value"
+                  >
+                    <ion-select-option :value="10">10</ion-select-option>
+                    <ion-select-option :value="20">20</ion-select-option>
+                    <ion-select-option :value="50">50</ion-select-option>
+                    <ion-select-option :value="100">100</ion-select-option>
+                    <ion-select-option :value="200">200</ion-select-option>
+                    <ion-select-option :value="500">500</ion-select-option>
+                  </ion-select>
+                </div>
+                <div class="pagination-buttons">
+                  <ion-button fill="clear" slot="icon-only" :disabled="pageIndex === 0" @click="goToPreviousPage">
+                    <ion-icon :icon="caretBackOutline" />
+                  </ion-button>
+                  <ion-note color="medium">{{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
+                  <ion-button fill="clear" slot="icon-only" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
+                    <ion-icon :icon="caretForwardOutline" />
+                  </ion-button>
+                </div>
               </div>
 
               <SystemMessageList
@@ -151,7 +169,7 @@ import { caretBackOutline, caretForwardOutline } from "ionicons/icons";
 // Type based declaration
 const props = defineProps<{ id?: string }>();
 
-const PAGE_SIZE = 25;
+const pageSize = ref(25);
 const pageIndex = ref(0);
 
 const systemMessageStore = useSystemMessageStore();
@@ -184,7 +202,7 @@ const pageTitle = computed(() => isCreateMode.value ? translate("Create Remote S
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
 const relatedMessages = computed(() => systemMessageStore.getSystemMessages);
 const total = computed(() => systemMessageStore.getSystemMessageTotal);
-const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const pageCount = computed(() => Math.max(Math.ceil(total.value / pageSize.value), 1));
 
 const setForm = (payload?: Record<string, any>) => {
   for (const key of Object.keys(form)) {
@@ -207,7 +225,7 @@ const loadRemote = async () => {
     await systemMessageStore.fetchSystemMessages({
       systemMessageRemoteId: props.id,
       pageIndex: pageIndex.value,
-      pageSize: PAGE_SIZE,
+      pageSize: pageSize.value,
     })
     setForm(entity);
   } else {
@@ -260,28 +278,33 @@ const goToPreviousPage = () => {
 const goToNextPage = () => {
   pageIndex.value += 1;
 };
-
-watch([queryString, selectedStatusId], () => {
-  pageIndex.value = 0
-})
-
-watch([pageIndex], async () => {
+const fetchRelatedMessages = async () => {
   const payload = {
     systemMessageRemoteId: props.id,
     pageIndex: pageIndex.value,
-    pageSize: PAGE_SIZE
+    pageSize: pageSize.value
   } as Record<string, any>
 
-  if(queryString.value.trim()) {
+  if (queryString.value.trim()) {
     payload["queryString"] = queryString.value.trim().toLowerCase()
   }
 
-  if(selectedStatusId.value) {
+  if (selectedStatusId.value) {
     payload["statusId"] = selectedStatusId.value;
   }
 
   await systemMessageStore.fetchSystemMessages(payload)
+};
+
+watch([queryString, selectedStatusId, pageSize], async () => {
+  if (pageIndex.value !== 0) {
+    pageIndex.value = 0;
+  } else {
+    await fetchRelatedMessages();
+  }
 });
+
+watch(pageIndex, fetchRelatedMessages);
 
 onIonViewWillEnter(() => {
   pageIndex.value = 0
@@ -307,8 +330,20 @@ onIonViewWillEnter(() => {
 
 .pagination {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   gap: 10px;
+}
+
+.pagination-buttons {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.limit-container {
+  display: flex;
+  align-items: center;
+  max-width: 150px;
 }
 </style>

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -94,7 +94,7 @@
               <div class="pagination">
                 <div class="limit-container">
                   <ion-select
-                    :label="translate('Limit')"
+                    :label="translate('pageSize')"
                     label-placement="start"
                     interface="popover"
                     :value="pageSize"
@@ -169,7 +169,7 @@ import { caretBackOutline, caretForwardOutline } from "ionicons/icons";
 // Type based declaration
 const props = defineProps<{ id?: string }>();
 
-const pageSize = ref(25);
+const pageSize = ref(20);
 const pageIndex = ref(0);
 
 const systemMessageStore = useSystemMessageStore();
@@ -293,7 +293,7 @@ const fetchRelatedMessages = async () => {
     payload["statusId"] = selectedStatusId.value;
   }
 
-  await systemMessageStore.fetchSystemMessages(payload)
+  await systemMessageStore.fetchSystemMessages(payload);
 };
 
 watch([queryString, selectedStatusId, pageSize], async () => {


### PR DESCRIPTION
### Related Issues
Enhancement Request: Configurable Record Limit #918
#

### Short Description and Why It's Useful
Added a configurable record limit selector in the Monitor and Remote Systems tabs.

Users can now choose the number of records displayed per page from predefined options (10, 20, 50, 100, 200, and 500). The selected limit is applied immediately to the listing, reducing excessive pagination and improving data visibility when working with large datasets.


### Screenshots of Visual Changes  after
<img width="1292" height="418" alt="image" src="https://github.com/user-attachments/assets/c868d9bd-8b73-424c-b0e8-86ae3504afbe" />

Before:
1. Fixed display limit of 25 records.
2. No option available to change the number of displayed records.

After:

1. Added a record limit selector.
2. Users can select from 10, 20, 50, 100, 200, or 500 records per page.
3. The listing refreshes automatically based on the selected limit.