### PR TITLE
refactor: moved legacy app link to settings page

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -14,20 +14,11 @@
             button
             router-direction="root"
             :router-link="page.url"
-            class="hydrated"
             :class="{ selected: selectedIndex === index }">
             <ion-icon slot="start" :ios="page.iosIcon" :md="page.mdIcon" />
             <ion-label>{{ translate(page.title) }}</ion-label>
           </ion-item>
-          <ion-item
-            v-else-if="page.action"
-            button
-            @click="page.action()"
-            class="hydrated"
-            :class="{ selected: selectedIndex === index }">
-            <ion-icon slot="start" :ios="page.iosIcon" :md="page.mdIcon" />
-            <ion-label>{{ translate(page.title) }}</ion-label>
-          </ion-item>
+
           <ion-item-divider color="light" v-else>
             <ion-label color="medium">{{ translate(page.title) }}</ion-label>
           </ion-item-divider> 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -102,7 +102,6 @@ import {
   constructOutline,
   documentTextOutline,
   fileTrayStackedOutline,
-  gitNetworkOutline,
   globeOutline,
   pulseOutline,
   searchCircleOutline,
@@ -122,7 +121,6 @@ const userProfile = computed(() => userStore.getUserProfile);
 
 const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-// Filtering array of app pages, retaining only those elements (pages) that have the necessary permissions for display.
 const getValidMenuItems = (appPages: any) => {
   return appPages.filter(
     (appPage: any) =>
@@ -203,13 +201,7 @@ let appPages = [
     mdIcon: documentTextOutline,
     childRoutes: ["/data-documents/"],
   },
-  // {
-  //   title: "Feeds",
-  //   url: "/data-document-feeds",
-  //   iosIcon: gitNetworkOutline,
-  //   mdIcon: gitNetworkOutline,
-  //   childRoutes: ["/data-document-feeds/"]
-  // },
+
   {
     title: "Export History",
     url: "/data-document-export-history",

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,5 +1,10 @@
 <template>
-  <ion-menu side="start" content-id="main-content" type="overlay" :disabled="!isAuthenticated || router.currentRoute.value.path === '/login'">
+  <ion-menu
+    side="start"
+    content-id="main-content"
+    type="overlay"
+    :disabled="!isAuthenticated || router.currentRoute.value.path === '/login'"
+  >
     <ion-header>
       <ion-toolbar>
         <ion-title>{{ translate("Job Manager") }}</ion-title>
@@ -8,20 +13,25 @@
 
     <ion-content>
       <ion-list>
-        <ion-menu-toggle :auto-hide="false" v-for="(page, index) in getValidMenuItems(appPages)" :key="index">
+        <ion-menu-toggle
+          :auto-hide="false"
+          v-for="(page, index) in getValidMenuItems(appPages)"
+          :key="index"
+        >
           <ion-item
             v-if="page.url"
             button
             router-direction="root"
             :router-link="page.url"
-            :class="{ selected: selectedIndex === index }">
+            :class="{ selected: selectedIndex === index }"
+          >
             <ion-icon slot="start" :ios="page.iosIcon" :md="page.mdIcon" />
             <ion-label>{{ translate(page.title) }}</ion-label>
           </ion-item>
 
           <ion-item-divider color="light" v-else>
             <ion-label color="medium">{{ translate(page.title) }}</ion-label>
-          </ion-item-divider> 
+          </ion-item-divider>
         </ion-menu-toggle>
       </ion-list>
     </ion-content>
@@ -32,13 +42,28 @@
           <ion-label class="ion-text-wrap">
             <p class="overline">{{ commonUtil.getOmsURL() }}</p>
           </ion-label>
-          <ion-note :color="browserTimeZone === userStore.current?.timeZone ? '' : 'danger'" slot="end">{{ userStore.current?.timeZone }}</ion-note>
+          <ion-note
+            :color="
+              browserTimeZone === userStore.current?.timeZone ? '' : 'danger'
+            "
+            slot="end"
+            >{{ userStore.current?.timeZone }}</ion-note
+          >
         </ion-item>
         <!-- showing product stores only when there are multiple options to choose from. -->
         <ion-item v-if="userProfile.stores?.length > 2" lines="none">
           <!-- WHY EVENTS ($emit) IS USED WITH ION CHANGE: https://michaelnthiessen.com/pass-function-as-prop/ -->
-          <ion-select interface="popover" :value="currentProductStore.productStoreId" @ionChange="setProductStore($event.target.value)">
-            <ion-select-option v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" :value="store.productStoreId" >{{ store.storeName || store.productStoreId }}</ion-select-option>
+          <ion-select
+            interface="popover"
+            :value="currentProductStore.productStoreId"
+            @ionChange="setProductStore($event.target.value)"
+          >
+            <ion-select-option
+              v-for="store in userProfile ? userProfile.stores : []"
+              :key="store.productStoreId"
+              :value="store.productStoreId"
+              >{{ store.storeName || store.productStoreId }}</ion-select-option
+            >
           </ion-select>
         </ion-item>
         <ion-item v-else lines="none">
@@ -52,27 +77,60 @@
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonFooter, IonHeader, IonIcon, IonItem, IonItemDivider, IonLabel, IonList, IonMenu, IonMenuToggle, IonNote, IonSelect, IonSelectOption, IonTitle, IonToolbar } from "@ionic/vue";
+import {
+  IonContent,
+  IonFooter,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonItemDivider,
+  IonLabel,
+  IonList,
+  IonMenu,
+  IonMenuToggle,
+  IonNote,
+  IonSelect,
+  IonSelectOption,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/vue";
 import { computed } from "vue";
-import { albumsOutline, cloudDownloadOutline, cloudUploadOutline, constructOutline, documentTextOutline, fileTrayStackedOutline, gitNetworkOutline, globeOutline, openOutline, pulseOutline, searchCircleOutline, settingsOutline, timeOutline } from "ionicons/icons";
+import {
+  albumsOutline,
+  cloudDownloadOutline,
+  cloudUploadOutline,
+  constructOutline,
+  documentTextOutline,
+  fileTrayStackedOutline,
+  gitNetworkOutline,
+  globeOutline,
+  pulseOutline,
+  searchCircleOutline,
+  settingsOutline,
+  timeOutline,
+} from "ionicons/icons";
 import { translate, commonUtil, emitter } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import router from "../router";
 import { useUserStore } from "@/store/user";
-import { redirectToLegacyApp } from "@/utils";
 
 const { isAuthenticated } = useAuth();
 const userStore = useUserStore();
 
-const currentProductStore = computed(() => userStore.getCurrentProductStore)
-const userProfile = computed(() => userStore.getUserProfile)
+const currentProductStore = computed(() => userStore.getCurrentProductStore);
+const userProfile = computed(() => userStore.getUserProfile);
 
-const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 // Filtering array of app pages, retaining only those elements (pages) that have the necessary permissions for display.
 const getValidMenuItems = (appPages: any) => {
-  return appPages.filter((appPage: any) => (!appPage.meta || !appPage.meta.permissionId) || userStore.hasPermission(appPage.meta.permissionId));
-}
+  return appPages.filter(
+    (appPage: any) =>
+      !appPage.meta ||
+      !appPage.meta.permissionId ||
+      userStore.hasPermission(appPage.meta.permissionId),
+  );
+};
 
 let appPages = [
   {
@@ -81,69 +139,69 @@ let appPages = [
     iosIcon: pulseOutline,
     mdIcon: pulseOutline,
     meta: {
-      permissionId: "HIDDEN"
-    }
+      permissionId: "HIDDEN",
+    },
   },
   {
-    title: "Jobs"
+    title: "Jobs",
   },
   {
     title: "Catalog",
     url: "/catalog",
     iosIcon: albumsOutline,
     mdIcon: albumsOutline,
-    childRoutes: ["/job/"]
+    childRoutes: ["/job/"],
   },
   {
-    title: "MDM"
+    title: "MDM",
   },
   {
     title: "File history",
     url: "/file-history",
     iosIcon: timeOutline,
     mdIcon: timeOutline,
-    childRoutes: ["/file-history/"]
+    childRoutes: ["/file-history/"],
   },
   {
     title: "Manual uploads",
     url: "/manual-uploads",
     iosIcon: cloudUploadOutline,
     mdIcon: cloudUploadOutline,
-    childRoutes: ["/manual-uploads/"]
+    childRoutes: ["/manual-uploads/"],
   },
   {
-    title: "System Messages"
+    title: "System Messages",
   },
   {
     title: "Monitor",
     url: "/system-messages",
     iosIcon: pulseOutline,
     mdIcon: pulseOutline,
-    childRoutes: ["/system-messages/"]
+    childRoutes: ["/system-messages/"],
   },
   {
     title: "Message Types",
     url: "/system-message-types",
     iosIcon: fileTrayStackedOutline,
     mdIcon: fileTrayStackedOutline,
-    childRoutes: ["/system-message-types/"]
+    childRoutes: ["/system-message-types/"],
   },
   {
     title: "Remote Systems",
     url: "/system-message-remotes",
     iosIcon: globeOutline,
     mdIcon: globeOutline,
-    childRoutes: ["/system-message-remotes/"]
+    childRoutes: ["/system-message-remotes/"],
   },
   {
-    title: "Data Documents"
+    title: "Data Documents",
   },
   {
     title: "Documents",
     url: "/data-documents",
     iosIcon: documentTextOutline,
     mdIcon: documentTextOutline,
-    childRoutes: ["/data-documents/"]
+    childRoutes: ["/data-documents/"],
   },
   // {
   //   title: "Feeds",
@@ -157,10 +215,10 @@ let appPages = [
     url: "/data-document-export-history",
     iosIcon: cloudDownloadOutline,
     mdIcon: cloudDownloadOutline,
-    childRoutes: ["/data-document-export-history/"]
+    childRoutes: ["/data-document-export-history/"],
   },
   {
-    title: "System Health"
+    title: "System Health",
   },
   {
     title: "Solr Monitoring",
@@ -175,7 +233,7 @@ let appPages = [
     mdIcon: constructOutline,
   },
   {
-    title: "Settings"
+    title: "Settings",
   },
   {
     title: "Settings",
@@ -186,9 +244,14 @@ let appPages = [
 ] as any;
 
 const selectedIndex = computed(() => {
-  const path = router.currentRoute.value.path
-  return getValidMenuItems(appPages).findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path) || screen.childRoutes?.some((route: string) => path.includes(route)))
-})
+  const path = router.currentRoute.value.path;
+  return getValidMenuItems(appPages).findIndex(
+    (screen: any) =>
+      screen.url === path ||
+      screen.childRoutes?.includes(path) ||
+      screen.childRoutes?.some((route: string) => path.includes(route)),
+  );
+});
 
 const setProductStore = async (value: string) => {
   // If the value is same, no need to update
@@ -196,11 +259,11 @@ const setProductStore = async (value: string) => {
   // https://github.com/ionic-team/ionic-framework/discussions/25532
   // https://github.com/ionic-team/ionic-framework/issues/20106
   // https://github.com/ionic-team/ionic-framework/pull/25858
-  if(userStore.current && currentProductStore?.productStoreId !== value) {
-    await userStore.setCurrentProductStore({ "productStoreId": value })
-    emitter.emit("productStoreUpdated")
+  if (userStore.current && currentProductStore?.productStoreId !== value) {
+    await userStore.setCurrentProductStore({ productStoreId: value });
+    emitter.emit("productStoreUpdated");
   }
-}
+};
 </script>
 
 <style scoped>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -8,19 +8,21 @@
 
     <ion-content>
       <ion-list>
-        <ion-item
-          button
-          @click="redirectToLegacyApp()"
-        >
-          <ion-icon slot="start" :icon="openOutline" />
-          <ion-label>{{ translate("Legacy App") }}</ion-label>
-        </ion-item>
         <ion-menu-toggle :auto-hide="false" v-for="(page, index) in getValidMenuItems(appPages)" :key="index">
           <ion-item
             v-if="page.url"
             button
             router-direction="root"
             :router-link="page.url"
+            class="hydrated"
+            :class="{ selected: selectedIndex === index }">
+            <ion-icon slot="start" :ios="page.iosIcon" :md="page.mdIcon" />
+            <ion-label>{{ translate(page.title) }}</ion-label>
+          </ion-item>
+          <ion-item
+            v-else-if="page.action"
+            button
+            @click="page.action()"
             class="hydrated"
             :class="{ selected: selectedIndex === index }">
             <ion-icon slot="start" :ios="page.iosIcon" :md="page.mdIcon" />

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -246,11 +246,6 @@ const selectedIndex = computed(() => {
 });
 
 const setProductStore = async (value: string) => {
-  // If the value is same, no need to update
-  // Handled case for programmatical changes
-  // https://github.com/ionic-team/ionic-framework/discussions/25532
-  // https://github.com/ionic-team/ionic-framework/issues/20106
-  // https://github.com/ionic-team/ionic-framework/pull/25858
   if (userStore.current && currentProductStore?.productStoreId !== value) {
     await userStore.setCurrentProductStore({ productStoreId: value });
     emitter.emit("productStoreUpdated");

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -259,7 +259,7 @@ import Image from '@/components/Image.vue'
 import { cookieHelper, commonUtil, translate } from '@common';
 import { useAuth } from '@common/composables/useAuth';
 import { DateTime } from 'luxon';
-import { redirectToLegacyApp } from '@/utils';
+import { redirectToLegacyApp } from "@/utils";
 
 const userStore = useUserStore();
 const utilStore = useUtilStore();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -229,6 +229,21 @@
             </ion-item>
           </ion-list>
         </ion-card>
+
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>
+              {{ translate('Legacy App') }}
+            </ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            {{ translate('Access the legacy application for backward compatibility and features not yet migrated.') }}
+          </ion-card-content>
+          <ion-button fill="clear" @click="redirectToLegacyApp()">
+            {{ translate('Go to Legacy App') }}
+            <ion-icon slot="end" :icon="openOutline" />
+          </ion-button>
+        </ion-card>
       </section>
     </ion-content>
   </ion-page>
@@ -244,6 +259,7 @@ import Image from '@/components/Image.vue'
 import { cookieHelper, commonUtil, translate } from '@common';
 import { useAuth } from '@common/composables/useAuth';
 import { DateTime } from 'luxon';
+import { redirectToLegacyApp } from '@/utils';
 
 const userStore = useUserStore();
 const utilStore = useUtilStore();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -233,14 +233,14 @@
         <ion-card>
           <ion-card-header>
             <ion-card-title>
-              {{ translate('Legacy App') }}
+              {{ translate("Legacy App") }}
             </ion-card-title>
           </ion-card-header>
           <ion-card-content>
-            {{ translate('Access the legacy application for backward compatibility and features not yet migrated.') }}
+            {{ translate("Access the legacy application for backward compatibility and features not yet migrated.") }}
           </ion-card-content>
           <ion-button fill="clear" @click="redirectToLegacyApp()">
-            {{ translate('Go to Legacy App') }}
+            {{ translate("Go to Legacy App") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
         </ion-card>


### PR DESCRIPTION
Moved the Legacy App access from the main sidebar into the Settings page under the App section. It makes more sense there and cleans up the sidebar navigation.