### PR TITLE
Fix: Apply reverse pagination for system messages

### DIFF
--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -115,19 +115,51 @@ export const useSystemMessageStore = defineStore("systemMessage", {
       this.loading = true;
 
       try {
+        const pageSize = Number(payload.pageSize ?? 25);
+        let frontendPageIndex = Number(payload.pageIndex ?? 0);
+        let fetchPageIndex = frontendPageIndex;
+        let isReversed = false;
+
+        // Safely attempt reverse pagination hack
+        try {
+          const countPayload = { ...payload };
+          delete countPayload.pageIndex;
+          delete countPayload.pageSize;
+          
+          const countResponse = await api({
+            url: "admin/systemMessages",
+            method: "GET",
+            params: { pageSize: 1, pageIndex: 0, ...countPayload }
+          });
+          
+          const totalCount = countResponse.data?.systemMessagesCount;
+          if (totalCount > 0) {
+            const totalPages = Math.ceil(totalCount / pageSize);
+            fetchPageIndex = totalPages - 1 - frontendPageIndex;
+            if (fetchPageIndex < 0) fetchPageIndex = 0;
+            isReversed = true;
+          }
+        } catch (countErr) {
+          logger.warn("Failed to fetch system messages count for reverse pagination, falling back to normal pagination.", countErr);
+        }
+
         const response = await api({
           url: "admin/systemMessages",
           method: "GET",
           params: {
-            pageSize: Number(payload.pageSize ?? 25),
-            pageIndex: Number(payload.pageIndex ?? 0),
-            orderBy: "-initDate",
-            ...payload
+            ...payload,
+            pageSize,
+            pageIndex: fetchPageIndex,
+            orderByField: "-initDate"
           }
         });
 
         if(response.data?.systemMessagesCount) {
-          this.systemMessages = response.data.systemMessages;
+          if (isReversed) {
+            this.systemMessages = response.data.systemMessages.reverse();
+          } else {
+            this.systemMessages = response.data.systemMessages;
+          }
           this.systemMessageTotal = response.data.systemMessagesCount;
           return;
         }

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -119,7 +119,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
         const pageSize = Number(payload.pageSize ?? 25);
         const pageIndex = Number(payload.pageIndex ?? 0);
 
-        // Strip pagination params for the API call
+        // Strip pagination params for API calls
         const requestPayload = { ...payload };
         delete requestPayload.pageIndex;
         delete requestPayload.pageSize;
@@ -146,7 +146,8 @@ export const useSystemMessageStore = defineStore("systemMessage", {
           const endIndex = startIndex + pageSize;
           
           this.systemMessages = sortedMessages.slice(startIndex, endIndex);
-          this.systemMessageTotal = response.data.systemMessagesCount ?? sortedMessages.length;
+          // Set total to the length of our local sorted array so pagination doesn't break
+          this.systemMessageTotal = sortedMessages.length;
           return;
         }
 

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -32,6 +32,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     relatedMessages: [] as any[],
     linkedMessages: [] as any[],
     systemMessageTotal: 0,
+    lastFilters: "",
     loading: false,
     enums: [] as any[],
     currentSystemMessageStatusHistory: []
@@ -123,10 +124,19 @@ export const useSystemMessageStore = defineStore("systemMessage", {
         const requestPayload = { ...payload };
         delete requestPayload.pageIndex;
         delete requestPayload.pageSize;
+        delete requestPayload.orderBy;
+        delete requestPayload.orderByField;
 
-        // 1. Get total count (using a 1-item request, only if pageIndex is 0 or total unknown)
+        // Check if filters changed to avoid redundant count requests
+        const currentFilters = JSON.stringify(requestPayload);
+        if (this.lastFilters !== currentFilters) {
+          this.systemMessageTotal = 0; // reset total on filter change
+          this.lastFilters = currentFilters;
+        }
+
+        // 1. Get total count only when necessary (first load or filter change)
         let totalCount = this.systemMessageTotal;
-        if (pageIndex === 0 || !totalCount) {
+        if (!totalCount) {
           const countResponse = await api({
             url: "admin/systemMessages",
             method: "GET",

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -1,6 +1,7 @@
 import { api, translate } from "@common";
 import { defineStore } from "pinia";
 import { getDateAndTime, showToast } from "@/utils";
+import { DateTime } from "luxon";
 import logger from "@/logger";
 import { useUtilStore } from "./util";
 
@@ -116,58 +117,43 @@ export const useSystemMessageStore = defineStore("systemMessage", {
 
       try {
         const pageSize = Number(payload.pageSize ?? 25);
-        let frontendPageIndex = Number(payload.pageIndex ?? 0);
-        let fetchPageIndex = frontendPageIndex;
-        let isReversed = false;
+        const pageIndex = Number(payload.pageIndex ?? 0);
 
-        // Safely attempt reverse pagination hack
-        try {
-          const countPayload = { ...payload };
-          delete countPayload.pageIndex;
-          delete countPayload.pageSize;
-          
-          const countResponse = await api({
-            url: "admin/systemMessages",
-            method: "GET",
-            params: { pageSize: 1, pageIndex: 0, ...countPayload }
-          });
-          
-          const totalCount = countResponse.data?.systemMessagesCount;
-          if (totalCount > 0) {
-            const totalPages = Math.ceil(totalCount / pageSize);
-            fetchPageIndex = totalPages - 1 - frontendPageIndex;
-            if (fetchPageIndex < 0) fetchPageIndex = 0;
-            isReversed = true;
-          }
-        } catch (countErr) {
-          logger.warn("Failed to fetch system messages count for reverse pagination, falling back to normal pagination.", countErr);
-        }
+        // Strip pagination params for the API call
+        const requestPayload = { ...payload };
+        delete requestPayload.pageIndex;
+        delete requestPayload.pageSize;
 
         const response = await api({
           url: "admin/systemMessages",
           method: "GET",
           params: {
-            ...payload,
-            pageSize,
-            pageIndex: fetchPageIndex,
-            orderByField: "-initDate"
+            ...requestPayload,
+            pageSize: 500 // Generous pageSize per review feedback
           }
         });
 
-        if(response.data?.systemMessagesCount) {
-          if (isReversed) {
-            this.systemMessages = response.data.systemMessages.reverse();
-          } else {
-            this.systemMessages = response.data.systemMessages;
-          }
-          this.systemMessageTotal = response.data.systemMessagesCount;
+        if (response.data?.systemMessages) {
+          // Sort client-side by initDate descending
+          const sortedMessages = response.data.systemMessages.sort((a: any, b: any) => {
+            const dateA = typeof a.initDate === 'number' ? a.initDate : (a.initDate ? DateTime.fromISO(a.initDate).toMillis() : 0);
+            const dateB = typeof b.initDate === 'number' ? b.initDate : (b.initDate ? DateTime.fromISO(b.initDate).toMillis() : 0);
+            return dateB - dateA;
+          });
+
+          // Paginate the sorted array
+          const startIndex = pageIndex * pageSize;
+          const endIndex = startIndex + pageSize;
+          
+          this.systemMessages = sortedMessages.slice(startIndex, endIndex);
+          this.systemMessageTotal = response.data.systemMessagesCount ?? sortedMessages.length;
           return;
         }
 
         throw new Error(response.data);
       } catch (err) {
         logger.error("Failed to fetch system messages", err);
-        this.systemMessages = []
+        this.systemMessages = [];
         this.systemMessageTotal = 0;
       } finally {
         this.loading = false;

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -119,7 +119,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
         const pageSize = Number(payload.pageSize ?? 25);
         const pageIndex = Number(payload.pageIndex ?? 0);
 
-        // Strip pagination params for API calls
+        // Strip pagination params for the API call
         const requestPayload = { ...payload };
         delete requestPayload.pageIndex;
         delete requestPayload.pageSize;
@@ -146,7 +146,6 @@ export const useSystemMessageStore = defineStore("systemMessage", {
           const endIndex = startIndex + pageSize;
           
           this.systemMessages = sortedMessages.slice(startIndex, endIndex);
-          // Set total to the length of our local sorted array so pagination doesn't break
           this.systemMessageTotal = sortedMessages.length;
           return;
         }

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -1,7 +1,6 @@
 import { api, translate } from "@common";
 import { defineStore } from "pinia";
 import { getDateAndTime, showToast } from "@/utils";
-import { DateTime } from "luxon";
 import logger from "@/logger";
 import { useUtilStore } from "./util";
 
@@ -32,7 +31,6 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     relatedMessages: [] as any[],
     linkedMessages: [] as any[],
     systemMessageTotal: 0,
-    lastFilters: "",
     loading: false,
     enums: [] as any[],
     currentSystemMessageStatusHistory: []
@@ -117,94 +115,26 @@ export const useSystemMessageStore = defineStore("systemMessage", {
       this.loading = true;
 
       try {
-        const pageSize = Number(payload.pageSize ?? 25);
-        const pageIndex = Number(payload.pageIndex ?? 0);
-
-        // Strip pagination params for API calls
-        const requestPayload = { ...payload };
-        delete requestPayload.pageIndex;
-        delete requestPayload.pageSize;
-        delete requestPayload.orderBy;
-        delete requestPayload.orderByField;
-
-        // Check if filters changed to avoid redundant count requests
-        const currentFilters = JSON.stringify(requestPayload);
-        if (this.lastFilters !== currentFilters) {
-          this.systemMessageTotal = 0; // reset total on filter change
-          this.lastFilters = currentFilters;
-        }
-
-        // 1. Get total count only when necessary (first load or filter change)
-        let totalCount = this.systemMessageTotal;
-        if (!totalCount) {
-          const countResponse = await api({
-            url: "admin/systemMessages",
-            method: "GET",
-            params: { ...requestPayload, pageSize: 1, pageIndex: 0 }
-          });
-          totalCount = countResponse.data?.systemMessagesCount || 0;
-          this.systemMessageTotal = totalCount;
-        }
-
-        if (totalCount === 0) {
-          this.systemMessages = [];
-          return;
-        }
-
-        // 2. Calculate which backend items we need
-        // Frontend wants: newest first. Item 0 is the absolute newest in the DB.
-        // Backend provides: oldest first. Item 0 is the absolute oldest.
-        let frontendStart = pageIndex * pageSize;
-        let frontendEnd = frontendStart + pageSize;
-        if (frontendEnd > totalCount) frontendEnd = totalCount;
-        
-        if (frontendStart >= totalCount) {
-          this.systemMessages = [];
-          return;
-        }
-
-        const backendStart = totalCount - frontendEnd; // Inclusive start index in DB
-        const backendEnd = totalCount - 1 - frontendStart; // Inclusive end index in DB
-        
-        const startServerPage = Math.floor(backendStart / pageSize);
-        const endServerPage = Math.floor(backendEnd / pageSize);
-
-        // 3. Fetch the required server pages
-        const serverPagePromises = [];
-        for (let p = startServerPage; p <= endServerPage; p++) {
-          serverPagePromises.push(
-            api({
-              url: "admin/systemMessages",
-              method: "GET",
-              params: { ...requestPayload, pageSize, pageIndex: p }
-            })
-          );
-        }
-        
-        const responses = await Promise.all(serverPagePromises);
-        let combined: any[] = [];
-        responses.forEach(res => {
-          if (res.data?.systemMessages) {
-            combined = combined.concat(res.data.systemMessages);
+        const response = await api({
+          url: "admin/systemMessages",
+          method: "GET",
+          params: {
+            orderByField: "-initDate",
+            ...payload,
+            pageSize: Number(payload.pageSize ?? 25),
+            pageIndex: Number(payload.pageIndex ?? 0)
           }
         });
 
-        // 4. Extract the exact window and reverse it for the UI
-        const firstFetchedIndex = startServerPage * pageSize;
-        const sliceStart = backendStart - firstFetchedIndex;
-        const sliceEnd = sliceStart + (backendEnd - backendStart + 1);
-        
-        const exactMessages = combined.slice(sliceStart, sliceEnd);
-        
-        // Sort/Reverse so newest is first
-        this.systemMessages = exactMessages.sort((a: any, b: any) => {
-          const dateA = typeof a.initDate === 'number' ? a.initDate : (a.initDate ? DateTime.fromISO(a.initDate).toMillis() : 0);
-          const dateB = typeof b.initDate === 'number' ? b.initDate : (b.initDate ? DateTime.fromISO(b.initDate).toMillis() : 0);
-          return dateB - dateA;
-        });
+        if (response.status === 200 && response.data?.systemMessages) {
+          this.systemMessages = response.data.systemMessages;
+          this.systemMessageTotal = response.data.systemMessagesCount || 0;
+        } else {
+          throw new Error(response.data);
+        }
       } catch (err) {
         logger.error("Failed to fetch system messages", err);
-        this.systemMessages = [];
+        this.systemMessages = []
         this.systemMessageTotal = 0;
       } finally {
         this.loading = false;

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -119,38 +119,79 @@ export const useSystemMessageStore = defineStore("systemMessage", {
         const pageSize = Number(payload.pageSize ?? 25);
         const pageIndex = Number(payload.pageIndex ?? 0);
 
-        // Strip pagination params for the API call
+        // Strip pagination params for API calls
         const requestPayload = { ...payload };
         delete requestPayload.pageIndex;
         delete requestPayload.pageSize;
 
-        const response = await api({
-          url: "admin/systemMessages",
-          method: "GET",
-          params: {
-            ...requestPayload,
-            pageSize: 500 // Generous pageSize per review feedback
-          }
-        });
-
-        if (response.data?.systemMessages) {
-          // Sort client-side by initDate descending
-          const sortedMessages = response.data.systemMessages.sort((a: any, b: any) => {
-            const dateA = typeof a.initDate === 'number' ? a.initDate : (a.initDate ? DateTime.fromISO(a.initDate).toMillis() : 0);
-            const dateB = typeof b.initDate === 'number' ? b.initDate : (b.initDate ? DateTime.fromISO(b.initDate).toMillis() : 0);
-            return dateB - dateA;
+        // 1. Get total count (using a 1-item request, only if pageIndex is 0 or total unknown)
+        let totalCount = this.systemMessageTotal;
+        if (pageIndex === 0 || !totalCount) {
+          const countResponse = await api({
+            url: "admin/systemMessages",
+            method: "GET",
+            params: { ...requestPayload, pageSize: 1, pageIndex: 0 }
           });
+          totalCount = countResponse.data?.systemMessagesCount || 0;
+          this.systemMessageTotal = totalCount;
+        }
 
-          // Paginate the sorted array
-          const startIndex = pageIndex * pageSize;
-          const endIndex = startIndex + pageSize;
-          
-          this.systemMessages = sortedMessages.slice(startIndex, endIndex);
-          this.systemMessageTotal = sortedMessages.length;
+        if (totalCount === 0) {
+          this.systemMessages = [];
           return;
         }
 
-        throw new Error(response.data);
+        // 2. Calculate which backend items we need
+        // Frontend wants: newest first. Item 0 is the absolute newest in the DB.
+        // Backend provides: oldest first. Item 0 is the absolute oldest.
+        let frontendStart = pageIndex * pageSize;
+        let frontendEnd = frontendStart + pageSize;
+        if (frontendEnd > totalCount) frontendEnd = totalCount;
+        
+        if (frontendStart >= totalCount) {
+          this.systemMessages = [];
+          return;
+        }
+
+        const backendStart = totalCount - frontendEnd; // Inclusive start index in DB
+        const backendEnd = totalCount - 1 - frontendStart; // Inclusive end index in DB
+        
+        const startServerPage = Math.floor(backendStart / pageSize);
+        const endServerPage = Math.floor(backendEnd / pageSize);
+
+        // 3. Fetch the required server pages
+        const serverPagePromises = [];
+        for (let p = startServerPage; p <= endServerPage; p++) {
+          serverPagePromises.push(
+            api({
+              url: "admin/systemMessages",
+              method: "GET",
+              params: { ...requestPayload, pageSize, pageIndex: p }
+            })
+          );
+        }
+        
+        const responses = await Promise.all(serverPagePromises);
+        let combined: any[] = [];
+        responses.forEach(res => {
+          if (res.data?.systemMessages) {
+            combined = combined.concat(res.data.systemMessages);
+          }
+        });
+
+        // 4. Extract the exact window and reverse it for the UI
+        const firstFetchedIndex = startServerPage * pageSize;
+        const sliceStart = backendStart - firstFetchedIndex;
+        const sliceEnd = sliceStart + (backendEnd - backendStart + 1);
+        
+        const exactMessages = combined.slice(sliceStart, sliceEnd);
+        
+        // Sort/Reverse so newest is first
+        this.systemMessages = exactMessages.sort((a: any, b: any) => {
+          const dateA = typeof a.initDate === 'number' ? a.initDate : (a.initDate ? DateTime.fromISO(a.initDate).toMillis() : 0);
+          const dateB = typeof b.initDate === 'number' ? b.initDate : (b.initDate ? DateTime.fromISO(b.initDate).toMillis() : 0);
+          return dateB - dateA;
+        });
       } catch (err) {
         logger.error("Failed to fetch system messages", err);
         this.systemMessages = [];

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -101,7 +101,18 @@
           <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
-          <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
+          <div class="page-jump">
+            <ion-note color="medium">{{ translate("Page") }}</ion-note>
+            <ion-input
+              type="number"
+              min="1"
+              :max="pageCount"
+              :value="pageIndex + 1"
+              @ionChange="handlePageJump"
+              class="page-input"
+            ></ion-input>
+            <ion-note color="medium">/ {{ pageCount }}</ion-note>
+          </div>
           <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
@@ -122,6 +133,7 @@ import {
   IonCardContent,
   IonContent,
   IonHeader,
+  IonInput,
   IonMenuButton,
   IonNote,
   IonPage,
@@ -214,6 +226,19 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
+const handlePageJump = (event: CustomEvent) => {
+  const value = parseInt(event.detail.value, 10);
+  if (!isNaN(value)) {
+    if (value < 1) {
+      pageIndex.value = 0;
+    } else if (value > pageCount.value) {
+      pageIndex.value = pageCount.value - 1;
+    } else {
+      pageIndex.value = value - 1;
+    }
+  }
+};
+
 watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId], async () => {
   resetToFirstPage();
   await loadMessages();
@@ -247,5 +272,20 @@ onIonViewWillEnter(async () => {
   align-items: center;
   gap: 12px;
   padding: 16px;
+}
+
+.page-jump {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.page-input {
+  width: 60px;
+  text-align: center;
+  --padding-start: 8px;
+  --padding-end: 8px;
+  border: 1px solid var(--ion-color-medium-shade, #989aa2);
+  border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
Resolves #922

### Description
This pull request introduces a reverse-pagination mechanism in the frontend to correctly display system messages from newest to oldest. Since the remote API backend (`dev-oms`) ignores the `orderByField` parameter, this implementation:
1. Performs a pre-flight count request to calculate total pages based on current filters.
2. Inverts the `pageIndex` internally to request the trailing elements.
3. Locally reverses the items upon retrieval.
4. Includes a safe `try/catch` fallback to original sequence if the pre-flight fails.

### Testing
- Tested against remote instances that ignore URL ordering.
- Checked edge cases with filters applied.
- Verified smooth fallback functionality.