### PR TITLE
Enable IDE Trace Vue plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/luxon": "catalog:",
     "@types/file-saver": "catalog:",
     "@types/papaparse": "catalog:",
+    "chrome-ide-trace": "^0.1.0",
     "typescript": "~4.7.4",
     "eslint": "catalog:"
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@
 import legacy from '@vitejs/plugin-legacy'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
+import { ideTraceVue } from 'chrome-ide-trace/vite'
 import { defineConfig } from 'vite'
 import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
 import pkg from './package.json'
@@ -10,6 +11,7 @@ import pkg from './package.json'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    ideTraceVue(),
     vue(),
     legacy()
   ],


### PR DESCRIPTION
## Summary\n\nAdds IDE Trace plugin wiring to this app's Vite config and package config for Chrome DevTools integration from IDE Trace browser extension.\n\n## Files\n- package.json: add chrome-ide-trace devDependency\n- vite.config.{ts,js}: add ideTraceVue import and plugin entry