### PR TITLE
Update chrome-ide-trace to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/luxon": "catalog:",
     "@types/file-saver": "catalog:",
     "@types/papaparse": "catalog:",
-    "chrome-ide-trace": "^0.1.0",
+    "chrome-ide-trace": "^0.1.1",
     "typescript": "~4.7.4",
     "eslint": "catalog:"
   }


### PR DESCRIPTION
## Business summary
This app already uses IDE Trace during local development. Updating to chrome-ide-trace 0.1.1 lets developers get the new plugin-started localhost opener server from normal dependency installation, reducing local setup friction and avoiding a separate native host step for the common path.

Closes #941

## Changes
- Updates chrome-ide-trace from ^0.1.0 to ^0.1.1.

## Validation
- Verified chrome-ide-trace@0.1.1 is published as npm latest.
- Package-only change; no app source changed.
