### PR TITLE
Remove app-level chrome-ide-trace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@capacitor/android": "catalog:",
+    "@capacitor/clipboard": "catalog:",
     "@capacitor/core": "catalog:",
     "@capacitor/ios": "catalog:",
     "@casl/ability": "^6.0.0",
@@ -21,29 +22,27 @@
     "@ionic/core": "catalog:",
     "@ionic/vue": "catalog:",
     "@ionic/vue-router": "catalog:",
-    "vue-router": "catalog:",
-    "cronstrue": "catalog:",
-    "cron-parser": "catalog:",
     "boon-js": "^2.0.3",
+    "cron-parser": "catalog:",
+    "cronstrue": "catalog:",
     "file-saver": "catalog:",
     "luxon": "catalog:",
     "mitt": "catalog:",
+    "papaparse": "catalog:",
     "pinia": "catalog:",
     "pinia-plugin-persistedstate": "catalog:",
     "qs": "catalog:",
     "register-service-worker": "catalog:",
     "vue": "catalog:",
     "vue-logger-plugin": "catalog:",
-    "papaparse": "catalog:",
-    "@capacitor/clipboard": "catalog:"
+    "vue-router": "catalog:"
   },
   "devDependencies": {
     "@capacitor/cli": "catalog:",
-    "@types/luxon": "catalog:",
     "@types/file-saver": "catalog:",
+    "@types/luxon": "catalog:",
     "@types/papaparse": "catalog:",
-    "chrome-ide-trace": "^0.1.1",
-    "typescript": "~4.7.4",
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "typescript": "~4.7.4"
   }
 }


### PR DESCRIPTION
Business summary: Removes the app-local IDE Trace dependency so AccxUI can own the installed version centrally through its workspace catalog/root dev dependency.\n\nCloses https://github.com/hotwax/job-manager/issues/943