### PR TITLE
fix: format Parent Type dropdown labels for readability

### DIFF
--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -45,9 +45,9 @@ export const useSystemMessageStore = defineStore("systemMessage", {
       return parentTypeIds.map(id => ({
         id,
         description: id
-            .replace(/([a-z\d])([A-Z])/g, '$1 $2')
-            .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-            .trim()
+          .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+          .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+          .trim()
       })).sort((a, b) => a.description.localeCompare(b.description));
     },
     getCurrentSystemMessage: (state: any) => state.currentSystemMessage,

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -42,13 +42,13 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     getSystemMessageErrors: (state: any) => state.systemMessageErrors,
     getSystemMessageParentTypes: (state: any) => {
       const parentTypeIds = [...new Set(state.systemMessageTypes.map((type: any) => type.parentTypeId).filter(Boolean))] as string[];
-      return parentTypeIds.map(id => ({
-        id,
-        description: id
-          .replace(/([a-z\d])([A-Z])/g, "$1 $2")
-          .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
-          .trim()
-      })).sort((a, b) => a.description.localeCompare(b.description));
+      return parentTypeIds.map(id => {
+        const type = state.systemMessageTypes.find((t: any) => t.systemMessageTypeId === id);
+        return {
+          id,
+          description: type?.description || id
+        };
+      }).sort((a, b) => a.description.localeCompare(b.description));
     },
     getCurrentSystemMessage: (state: any) => state.currentSystemMessage,
     getCurrentSystemMessageType: (state: any) => state.currentSystemMessageType,

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -42,13 +42,13 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     getSystemMessageErrors: (state: any) => state.systemMessageErrors,
     getSystemMessageParentTypes: (state: any) => {
       const parentTypeIds = [...new Set(state.systemMessageTypes.map((type: any) => type.parentTypeId).filter(Boolean))] as string[];
-      return parentTypeIds.map(id => {
-        const type = state.systemMessageTypes.find((t: any) => t.systemMessageTypeId === id);
-        return {
-          id,
-          description: type?.description || id
-        };
-      }).sort((a, b) => a.description.localeCompare(b.description));
+      return parentTypeIds.map(id => ({
+        id,
+        description: id
+            .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+            .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+            .trim()
+      })).sort((a, b) => a.description.localeCompare(b.description));
     },
     getCurrentSystemMessage: (state: any) => state.currentSystemMessage,
     getCurrentSystemMessageType: (state: any) => state.currentSystemMessageType,

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -337,3 +337,19 @@ ion-select {
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
   gap: 16px;
 }
+
+ion-select::part(text) {
+  white-space: normal;
+}
+
+ion-select-popover ion-item {
+  --min-height: auto;
+  --padding-top: 10px;
+  --padding-bottom: 10px;
+}
+
+ion-select-popover ion-radio::part(label),
+ion-select-popover ion-checkbox::part(label) {
+  white-space: normal;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Description
This PR resolves the UI bug on the System Message Monitor page where the 'Parent Type' filter dropdown displayed verbose, system-generated descriptions. These long descriptions (e.g., "Parent SystemMessageType for Shopify Webhook") were previously getting truncated, making it difficult for users to distinguish between similar options like `ShopifyBulkImport` and `ShopifyWebhook`. 

By updating the state getter to format the `parentTypeId` directly, the dropdown now displays clean, concise, and human-readable labels.

## Changes Made
* Modified the `getSystemMessageParentTypes` getter in `src/store/systemMessage.ts`.
* Removed the mapping logic that fetched the verbose `description` property from `systemMessageTypes`.
* Implemented regex parsing to convert the CamelCase `id` strings into space-separated, readable formats (e.g., parsing `ShopifyBulkImport` into `Shopify Bulk Import`).

## Related Issue
Fixes #964