### PR TITLE
Fix: prevent status badge clipping on dashboard integration cards (#962)

### DIFF
--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -993,6 +993,7 @@ onIonViewWillLeave(() => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: var(--spacer-2xs);
+  gap: var(--spacer-xs);
 }
 
 .kpi-header ion-badge {

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -995,6 +995,11 @@ onIonViewWillLeave(() => {
   margin-bottom: var(--spacer-2xs);
 }
 
+.kpi-header ion-badge {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .kpi-subtext {
   display: flex;
   gap: var(--spacer-xs);


### PR DESCRIPTION
## Related Issue

Closes #962

## Problem

Status badges rendered on Integration Dashboard cards (such as **Action Required**, **Warnings**, **Healthy**, and **Active**) were being clipped and partially hidden. For example, **Action Required** was displayed as **Action Req**.

Additionally, cards with longer titles rendered badges immediately adjacent to the title text, resulting in insufficient visual spacing.

## Root Cause

Status badges are rendered inside a flex container whose children can shrink when horizontal space is limited. This caused longer badge labels to be compressed and truncated.

The KPI header layout also lacked spacing between the title and badge elements, causing badges to appear too close to long titles.

## Changes

- Updated badge styling in `Pipeline.vue` to prevent status badges from shrinking within the KPI header layout.
- Added `flex-shrink: 0` and `white-space: nowrap` to preserve the natural width of badges and keep badge text on a single line.
- Added `gap: var(--spacer-xs)` to the KPI header container to maintain consistent spacing between titles and badges.

## Evidence

Issue: #962

### Before
<img width="1850" height="911" alt="Image" src="https://github.com/user-attachments/assets/bd1b023b-3bf6-43e1-a002-c2f68e0931cb" />

### After
<img width="1854" height="1000" alt="Image" src="https://github.com/user-attachments/assets/10e6b555-e6fb-4fe7-9e50-14db06f80324" />

## Verification

- Verified that badges (**Active**, **Healthy**, **Warnings**, and **Action Required**) are fully visible without clipping.
- Verified that badge text remains on a single line.
- Verified that adequate spacing exists between long card titles and status badges.
- Verified that shorter badge labels continue to render correctly.
- Verified that no layout regressions occur on smaller screen widths.
- Ran `pnpm build` successfully.
- Ran `git diff --check` successfully.