### PR TITLE
Fix CSV Template Download Issue Causing Empty Files in Manual Uploads

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,11 +104,12 @@ const hasJobDataError = (job: any) => {
 
 const saveDataFile = async (response: any, fileName: string) => {
   let data;
+
   if (response instanceof Blob) {
     saveAs(response, fileName);
     return;
   }
-  
+
   if (typeof response === 'object') {
     data = JSON.stringify(response)
   } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,7 +104,11 @@ const hasJobDataError = (job: any) => {
 
 const saveDataFile = async (response: any, fileName: string) => {
   let data;
-
+  if (response instanceof Blob) {
+    saveAs(response, fileName);
+    return;
+  }
+  
   if (typeof response === 'object') {
     data = JSON.stringify(response)
   } else {


### PR DESCRIPTION
This PR fixes an issue in the Manual Uploads module where downloaded CSV template files were sometimes empty or corrupted.

The root cause was incorrect handling of API response data in the frontend download utility, where Blob responses were being incorrectly processed as JSON or stringified, leading to loss of binary data.

Problem
Download Template API returns CSV as a Blob
Frontend utility saveDataFile() was converting Blob using JSON.stringify()
This caused:
Empty CSV files
Corrupted downloads
Inconsistent behavior across different configurations

Solution
Updated saveDataFile() to properly handle Blob responses
Ensured Blob data is passed directly to file-saver
Prevented JSON/string conversion for binary file responses

Updated Logic
const saveDataFile = (response: any, fileName: string) => {
  if (response instanceof Blob) {
    saveAs(response, fileName);
    return;
  }

  const blob = new Blob(
    [typeof response === "object" ? JSON.stringify(response) : response],
    { type: "text/csv;charset=utf-8" }
  );

  saveAs(blob, fileName);
};

Closes #975