### PR TITLE
refactor: moved legacy app link from sidebar to settings page

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -8,13 +8,6 @@
 
     <ion-content>
       <ion-list>
-        <ion-item
-          button
-          @click="redirectToLegacyApp()"
-        >
-          <ion-icon slot="start" :icon="openOutline" />
-          <ion-label>{{ translate("Legacy App") }}</ion-label>
-        </ion-item>
         <ion-menu-toggle :auto-hide="false" v-for="(page, index) in getValidMenuItems(appPages)" :key="index">
           <ion-item
             v-if="page.url"
@@ -66,7 +59,6 @@ import { translate, commonUtil, emitter } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import router from "../router";
 import { useUserStore } from "@/store/user";
-import { redirectToLegacyApp } from "@/utils";
 
 const { isAuthenticated } = useAuth();
 const userStore = useUserStore();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -186,6 +186,7 @@
   "Function": "Function",
   "Generated path": "Generated path",
   "Go to Launchpad": "Go to Launchpad",
+  "Go to Legacy App": "Go to Legacy App",
   "Go to OMS": "Go to OMS",
   "Graph": "Graph",
   "Graph Builder": "Graph Builder",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -27,6 +27,10 @@
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
+          <ion-button fill="outline" @click="redirectToLegacyApp()">
+            {{ translate("Go to Legacy App") }}
+            <ion-icon slot="end" :icon="openOutline" />
+          </ion-button>
           <!-- Commenting this code as we currently do not have reset password functionality -->
           <!-- <ion-button fill="outline" color="medium">{{ translate("Reset password") }}</ion-button> -->
         </ion-card>
@@ -208,16 +212,18 @@
 </template>
 
 <script setup lang="ts">
-import { IonAvatar, IonButton, IonButtons, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader, IonIcon, IonItem, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar, IonModal, IonFab, IonFabButton, IonRadioGroup, IonSpinner, IonList, IonListHeader, IonRadio, IonSearchbar, IonLabel } from '@ionic/vue';
-import { computed, onBeforeMount, ref } from 'vue';
-import { closeOutline, openOutline, saveOutline, checkmarkCircle, closeCircle, syncOutline } from 'ionicons/icons'
-import { useUserStore } from '@/store/user';
-import { useUtilStore } from '@/store/util';
+import { cookieHelper, commonUtil, translate } from "@common";
+import { useAuth } from "@common/composables/useAuth";
+import { IonAvatar, IonButton, IonButtons, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader, IonIcon, IonItem, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar, IonModal, IonFab, IonFabButton, IonRadioGroup, IonSpinner, IonList, IonListHeader, IonRadio, IonSearchbar, IonLabel } from "@ionic/vue";
+import { closeOutline, openOutline, saveOutline, checkmarkCircle, closeCircle, syncOutline } from "ionicons/icons";
+import { DateTime } from "luxon";
+import { computed, onBeforeMount, ref } from "vue";
+
+import Image from "@/components/Image.vue";
 import { useMdmConfigStore } from "@/store/mdmConfig";
-import Image from '@/components/Image.vue'
-import { cookieHelper, commonUtil, translate } from '@common';
-import { useAuth } from '@common/composables/useAuth';
-import { DateTime } from 'luxon';
+import { useUserStore } from "@/store/user";
+import { useUtilStore } from "@/store/util";
+import { redirectToLegacyApp } from "@/utils";
 
 const userStore = useUserStore();
 const utilStore = useUtilStore();


### PR DESCRIPTION
Moved the Legacy App access from the main sidebar into the Settings page under the user profile section next to Go to Launchpad. This cleans up the sidebar navigation.