### PR TITLE
Fix average speed calculation for Dashboard KPI cards

### DIFF
--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -189,7 +189,7 @@
                 {{ translate(getLogStatusLabel(log)) }}
               </ion-badge>
               <p>{{ getFileSize(log.fileSize) }}</p>
-              <p>{{ log.createdDate && (log.finishDateTime || log.lastUpdatedStamp) ? getDuration(log.createdDate, log.finishDateTime || log.lastUpdatedStamp) : '-' }}</p>
+              <p>{{ log.createdDate && log.finishDateTime ? getDuration(log.createdDate, log.finishDateTime) : '-' }}</p>
               <ion-button v-if="log.statusId === 'DmlsPending'" color="danger" fill="clear" @click.stop="mdmStore.cancelDataManagerLog(log.configId, log.logId)">
                 <ion-icon slot="icon-only" :icon="closeOutline" />
               </ion-button>
@@ -721,7 +721,7 @@ onIonViewWillEnter(async () => {
   flex-direction: column;
   gap: 4px;
 }
-
+ 
 .detail-value.service-name {
   word-break: break-all;
 }

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -189,7 +189,7 @@
                 {{ translate(getLogStatusLabel(log)) }}
               </ion-badge>
               <p>{{ getFileSize(log.fileSize) }}</p>
-              <p>{{ log.createdDate && (log.finishDateTime || log.lastUpdatedTxStamp) ? getDuration(log.createdDate, log.finishDateTime || log.lastUpdatedTxStamp) : '-' }}</p>
+              <p>{{ log.createdDate && (log.finishDateTime || log.lastUpdatedStamp) ? getDuration(log.createdDate, log.finishDateTime || log.lastUpdatedStamp) : '-' }}</p>
               <ion-button v-if="log.statusId === 'DmlsPending'" color="danger" fill="clear" @click.stop="mdmStore.cancelDataManagerLog(log.configId, log.logId)">
                 <ion-icon slot="icon-only" :icon="closeOutline" />
               </ion-button>

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -720,7 +720,7 @@ const getAvgProcessingTime = (logsList: any[]) => {
   if (finishedLogs.length === 0) return 0;
   const totalSeconds = finishedLogs.reduce((acc, log) => {
     const start = log.createdDate;
-    const end = log.lastUpdatedStamp;
+    const end = log.finishDateTime || log.lastUpdatedTxStamp;
     if (!start || !end) return acc;
     const startDt = typeof start === 'number' ? DateTime.fromMillis(start) : DateTime.fromISO(start);
     const endDt = typeof end === 'number' ? DateTime.fromMillis(end) : DateTime.fromISO(end);
@@ -769,21 +769,24 @@ const pendingMessagesCount = computed(() => systemMessages.value.filter((msg: an
 const successMessagesCount = computed(() => systemMessages.value.filter((msg: any) => msg.statusId === 'SmsgSent' || msg.statusId === 'SmsgConsumed' || msg.statusId === 'SmsgConfirmed').length);
 
 // Inbound/Outbound Message Average Processing Time
+// Inbound/Outbound Message Average Processing Time
 const getAvgMessageProcessingTime = (messagesList: any[]) => {
   const finishedMessages = messagesList.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId));
   if (finishedMessages.length === 0) return 0;
-  const totalSeconds = finishedMessages.reduce((acc, msg) => {
+  const measurableMessages = finishedMessages.filter((msg: any) => msg.initDate && msg.processedDate);
+  if (measurableMessages.length === 0) return 0;
+  const totalSeconds = measurableMessages.reduce((acc, msg) => {
     const start = msg.initDate;
     const end = msg.processedDate;
-    if (!start || !end) return acc;
     const startDt = typeof start === 'number' ? DateTime.fromMillis(start) : DateTime.fromISO(start);
     const endDt = typeof end === 'number' ? DateTime.fromMillis(end) : DateTime.fromISO(end);
     if (!startDt.isValid || !endDt.isValid) return acc;
     const diff = endDt.diff(startDt, 'seconds').seconds;
     return acc + (diff > 0 ? diff : 0);
   }, 0);
-  return totalSeconds / finishedMessages.length;
+  return totalSeconds / measurableMessages.length;
 };
+
 
 const incomingAvgTime = computed(() => formatDuration(getAvgMessageProcessingTime(incomingMessages.value)));
 const outgoingAvgTime = computed(() => formatDuration(getAvgMessageProcessingTime(outgoingMessages.value)));

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -720,7 +720,7 @@ const getAvgProcessingTime = (logsList: any[]) => {
   if (finishedLogs.length === 0) return 0;
   const totalSeconds = finishedLogs.reduce((acc, log) => {
     const start = log.createdDate;
-    const end = log.finishDateTime || log.lastUpdatedTxStamp;
+    const end = log.finishDateTime || log.lastUpdatedStamp;
     if (!start || !end) return acc;
     const startDt = typeof start === 'number' ? DateTime.fromMillis(start) : DateTime.fromISO(start);
     const endDt = typeof end === 'number' ? DateTime.fromMillis(end) : DateTime.fromISO(end);
@@ -768,7 +768,6 @@ const erroredMessagesCount = computed(() => erroredMessages.value.length);
 const pendingMessagesCount = computed(() => systemMessages.value.filter((msg: any) => ['SmsgProduced', 'SmsgCreated', 'SmsgSending'].includes(msg.statusId) && !(msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
 const successMessagesCount = computed(() => systemMessages.value.filter((msg: any) => msg.statusId === 'SmsgSent' || msg.statusId === 'SmsgConsumed' || msg.statusId === 'SmsgConfirmed').length);
 
-// Inbound/Outbound Message Average Processing Time
 // Inbound/Outbound Message Average Processing Time
 const getAvgMessageProcessingTime = (messagesList: any[]) => {
   const finishedMessages = messagesList.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId));

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -724,7 +724,7 @@ const getAvgProcessingTime = (logsList: any[]) => {
   if (finishedLogs.length === 0) return 0;
   const totalSeconds = finishedLogs.reduce((acc, log) => {
     const start = log.createdDate;
-    const end = log.finishDateTime || log.lastUpdatedStamp;
+    const end = log.finishDateTime;
     if (!start || !end) return acc;
     const startDt = typeof start === 'number' ? DateTime.fromMillis(start) : DateTime.fromISO(start);
     const endDt = typeof end === 'number' ? DateTime.fromMillis(end) : DateTime.fromISO(end);
@@ -776,21 +776,19 @@ const successMessagesCount = computed(() => systemMessages.value.filter((msg: an
 const getAvgMessageProcessingTime = (messagesList: any[]) => {
   const finishedMessages = messagesList.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId));
   if (finishedMessages.length === 0) return 0;
-  const measurableMessages = finishedMessages.filter((msg: any) => msg.initDate && msg.processedDate);
-  if (measurableMessages.length === 0) return 0;
-  const totalSeconds = measurableMessages.reduce((acc, msg) => {
+  const totalSeconds = finishedMessages.reduce((acc, msg) => {
     const start = msg.initDate;
     const end = msg.processedDate;
+    if (!start || !end) return acc;
     const startDt = typeof start === 'number' ? DateTime.fromMillis(start) : DateTime.fromISO(start);
     const endDt = typeof end === 'number' ? DateTime.fromMillis(end) : DateTime.fromISO(end);
     if (!startDt.isValid || !endDt.isValid) return acc;
     const diff = endDt.diff(startDt, 'seconds').seconds;
     return acc + (diff > 0 ? diff : 0);
   }, 0);
-  return totalSeconds / measurableMessages.length;
+  return totalSeconds / finishedMessages.length;
 };
-
-
+ 
 const incomingAvgTime = computed(() => formatDuration(getAvgMessageProcessingTime(incomingMessages.value)));
 const outgoingAvgTime = computed(() => formatDuration(getAvgMessageProcessingTime(outgoingMessages.value)));
 


### PR DESCRIPTION
### Related Issues

Closes #1016 

### Short Description and Why It's Useful

This PR fixes the average speed calculations for the KPI cards on the Job Manager Dashboard. 
Previously, the Avg. Speed for High-priority and Standard ingestion was displaying as `--`, and Incoming messages was displaying as `0s`.

**Changes made:**
- **Ingestion Cards:** Corrected the end-time field mapping in `getAvgProcessingTime()` from `lastUpdatedStamp` (which was returning undefined/null) to `finishDateTime || lastUpdatedTxStamp` to properly calculate the duration.
- **Messages Card:** Fixed the `getAvgMessageProcessingTime()` calculation to first filter out messages that do not have a `processedDate`. Previously, these unmeasurable messages were being included in the denominator, artificially skewing the average down to 0.

This is useful because it ensures the Dashboard displays accurate and reliable performance metrics for system health monitoring.