### PR TITLE
Added: support to filter messages by inbound/outbound and improved pagination UI

### DIFF
--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -576,10 +576,10 @@ onIonViewWillEnter(async () => {
   } else {
     await mdmStore.updateAppliedFilters("statusId", []);
   }
-  if(currentQuery?.priority){
+  if (currentQuery?.priority) {
     selectedPriority.value = [(currentQuery.priority as string)];
-  }else{
-      selectedPriority.value = [];
+  } else {
+    selectedPriority.value = [];
   }
   await fetchLogs();
   mdmStore.fetchConfigs();

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -569,10 +569,17 @@ watch(pageIndex, () => {
 });
 
 onIonViewWillEnter(async () => {
-  if (route.query?.statusId) {
-    await mdmStore.updateAppliedFilters("statusId", (route.query.statusId as string).split(","));
+  const currentQuery = router.currentRoute.value.query;
+
+  if (currentQuery?.statusId) {
+    await mdmStore.updateAppliedFilters("statusId", (currentQuery.statusId as string).split(","));
   } else {
     await mdmStore.updateAppliedFilters("statusId", []);
+  }
+  if(currentQuery?.priority){
+    selectedPriority.value = [(currentQuery.priority as string)];
+  }else{
+      selectedPriority.value = [];
   }
   await fetchLogs();
   mdmStore.fetchConfigs();

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -199,7 +199,7 @@
                         <ion-icon slot="start" :icon="cloudUploadOutline" color="secondary" />
                         <ion-label>
                           {{ translate("High-Priority Queue") }}
-                          <p>{{ highPriorityPendingCount }} {{ translate("Pending Files") }}</p>
+                          <p>{{ mapHighPriorityCount }} {{ translate("Total Files") }}</p>
                         </ion-label>
                       </ion-item>
                       <div class="arrow-container">
@@ -209,7 +209,7 @@
                         <ion-icon slot="start" :icon="cloudUploadOutline" color="medium" />
                         <ion-label>
                           {{ translate("Standard Queue") }}
-                          <p>{{ standardPendingCount }} {{ translate("Pending Files") }}</p>
+                          <p>{{ mapStandardCount }} {{ translate("Total Files") }}</p>
                         </ion-label>
                       </ion-item>
                     </div>
@@ -225,7 +225,7 @@
                         <ion-icon slot="start" :icon="documentOutline" color="success" />
                         <ion-label>
                           {{ translate("Inbound Queue") }}
-                          <p>{{ incomingPendingCount }} {{ translate("Queued Inbound") }}</p>
+                          <p>{{ mapInboundCount }} {{ translate("Total Inbound") }}</p>
                         </ion-label>
                       </ion-item>
                       <div class="arrow-container">
@@ -235,7 +235,7 @@
                         <ion-icon slot="start" :icon="cloudDownloadOutline" color="primary" />
                         <ion-label>
                           {{ translate("Outbound Queue") }}
-                          <p>{{ outgoingPendingCount }} {{ translate("Queued Outbound") }}</p>
+                          <p>{{ mapOutboundCount }} {{ translate("Total Outbound") }}</p>
                         </ion-label>
                       </ion-item>
                     </div>
@@ -517,7 +517,7 @@ import {
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { DateTime } from "luxon";
 import router from "@/router";
-import { translate, emitter } from "@common";
+import { translate, emitter, api } from "@common";
 import { useJobStore } from "@/store/jobs";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useMdmConfigStore } from "@/store/mdmConfig";
@@ -708,15 +708,28 @@ const getLogPriority = (log: any) => {
 const highPriorityLogs = computed(() => logs.value.filter((log: any) => getLogPriority(log) > 6));
 const standardLogs = computed(() => logs.value.filter((log: any) => getLogPriority(log) <= 6));
 
-// Queue Depths (Pending / Queued / Running)
-const highPriorityPendingCount = computed(() => highPriorityLogs.value.filter((log: any) => ['DmlsPending', 'DmlsQueued', 'DmlsRunning'].includes(log.statusId)).length);
-const standardPendingCount = computed(() => standardLogs.value.filter((log: any) => ['DmlsPending', 'DmlsQueued', 'DmlsRunning'].includes(log.statusId)).length);
+// KPI chip counts — pending/queued status only, match what linked pages show
+const highPriorityPendingCount = ref(0);
+const standardPendingCount = ref(0);
+const incomingPendingCount = ref(0);
+const outgoingPendingCount = ref(0);
 
-// Ingestion throughput in latest 50
-const highPrioritySuccessCount = computed(() => highPriorityLogs.value.filter((log: any) => log.statusId === 'DmlsFinished').length);
-const standardSuccessCount = computed(() => standardLogs.value.filter((log: any) => log.statusId === 'DmlsFinished').length);
+// Queue Operations Map totals — read from store (matches what the linked pages show as their top-level count)
+// Note: the backend does not support priority or isOutgoing as server-side filters, so
+// we fetch a large batch and filter client-side just like the detail pages do.
+const mapHighPriorityCount = ref(0);
+const mapStandardCount = ref(0);
+const mapInboundCount = ref(0);
+const mapOutboundCount = ref(0);
+
+// KPI chip counts — finished status, fetched from API
+const highPrioritySuccessCount = ref(0);
+const standardSuccessCount = ref(0);
 const highPriorityFailedCount = computed(() => highPriorityLogs.value.filter((log: any) => ['DmlsCrashed', 'DmlsFailed'].includes(log.statusId) || (log.statusId === 'DmlsFinished' && Number(log.failedRecordCount || 0) > 0)).length);
 const standardFailedCount = computed(() => standardLogs.value.filter((log: any) => ['DmlsCrashed', 'DmlsFailed'].includes(log.statusId) || (log.statusId === 'DmlsFinished' && Number(log.failedRecordCount || 0) > 0)).length);
+// KPI chip counts — consumed/sent messages, fetched from API
+const incomingSuccessCount = ref(0);
+const outgoingSuccessCount = ref(0);
 
 // Ingestion Average Processing Time (Luxon end date - start date)
 const getAvgProcessingTime = (logsList: any[]) => {
@@ -757,14 +770,10 @@ const systemMessages = computed(() => systemMessageStore.getSystemMessages);
 const incomingMessages = computed(() => systemMessages.value.filter((msg: any) => msg.isOutgoing !== 'Y'));
 const outgoingMessages = computed(() => systemMessages.value.filter((msg: any) => msg.isOutgoing === 'Y'));
 
-// Incoming Stats
-const incomingPendingCount = computed(() => incomingMessages.value.filter((msg: any) => ['SmsgProduced', 'SmsgCreated', 'SmsgSending'].includes(msg.statusId) && !(msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
-const incomingSuccessCount = computed(() => incomingMessages.value.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId)).length);
+// Incoming Stats (error count from local 50-item page)
 const incomingErrorCount = computed(() => incomingMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
 
-// Outgoing Stats
-const outgoingPendingCount = computed(() => outgoingMessages.value.filter((msg: any) => ['SmsgProduced', 'SmsgCreated', 'SmsgSending'].includes(msg.statusId) && !(msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
-const outgoingSuccessCount = computed(() => outgoingMessages.value.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId)).length);
+// Outgoing Stats (error count from local 50-item page)
 const outgoingErrorCount = computed(() => outgoingMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
 
 const erroredMessages = computed(() => systemMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)));
@@ -927,6 +936,65 @@ const cancelDataManagerLog = async (configId: string, logId: string) => {
   }
 };
 
+const fetchQueueCounts = async () => {
+  const pendingStatuses = "DmlsPending,DmlsQueued,DmlsRunning";
+  const moquiStatuses = "DmlsCancelled,DmlsCrashed,DmlsFailed,DmlsFinished,DmlsPending,DmlsQueued,DmlsRunning";
+  
+  try {
+    const [
+      pendingLogsResp,
+      finishedLogsResp,
+      allLogsResp,
+      producedMsgsResp,
+      consumedMsgsResp,
+      sentMsgsResp,
+      allMsgsResp
+    ] = await Promise.all([
+      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: pendingStatuses, statusId_op: "in" } }),
+      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: "DmlsFinished" } }),
+      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: moquiStatuses, statusId_op: "in" } }),
+      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgProduced" } }),
+      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgConsumed" } }),
+      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgSent" } }),
+      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0 } })
+    ]);
+
+    const getLogPriority = (log: any) => {
+      const config = mdmStore.getConfigs.find((c: any) => c.configId === log.configId);
+      return config?.priority ? Number(config.priority) : 0;
+    };
+
+    const pendingLogs = pendingLogsResp.data?.dataManagerLogs || [];
+    highPriorityPendingCount.value = pendingLogs.filter((log: any) => getLogPriority(log) > 6).length;
+    standardPendingCount.value = pendingLogs.filter((log: any) => getLogPriority(log) <= 6).length;
+
+    const finishedLogs = finishedLogsResp.data?.dataManagerLogs || [];
+    highPrioritySuccessCount.value = finishedLogs.filter((log: any) => getLogPriority(log) > 6).length;
+    standardSuccessCount.value = finishedLogs.filter((log: any) => getLogPriority(log) <= 6).length;
+
+    const allLogs = allLogsResp.data?.dataManagerLogs || [];
+    mapHighPriorityCount.value = allLogs.filter((log: any) => getLogPriority(log) > 6).length;
+    mapStandardCount.value = allLogs.filter((log: any) => getLogPriority(log) <= 6).length;
+
+    const producedMsgs = producedMsgsResp.data?.systemMessages || [];
+    incomingPendingCount.value = producedMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
+    outgoingPendingCount.value = producedMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
+
+    const consumedMsgs = consumedMsgsResp.data?.systemMessages || [];
+    incomingSuccessCount.value = consumedMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
+
+    const sentMsgs = sentMsgsResp.data?.systemMessages || [];
+    outgoingSuccessCount.value = sentMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
+
+    const allMsgs = allMsgsResp.data?.systemMessages || [];
+    mapInboundCount.value = allMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
+    mapOutboundCount.value = allMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
+
+  } catch (err) {
+    console.error("Failed to fetch queue counts", err);
+  }
+};
+
 const refreshData = async () => {
   isLoading.value = true;
   try {
@@ -937,7 +1005,8 @@ const refreshData = async () => {
       mdmStore.fetchDataManagerLogs({ pageSize: 50 }),
       mdmStore.fetchConfigs(),
       utilStore.fetchStatusItemsByType("SystemMessage"),
-      utilStore.fetchStatusItemsByType("DataManagerLog")
+      utilStore.fetchStatusItemsByType("DataManagerLog"),
+      fetchQueueCounts()
     ]);
 
     // Fetch run history for active scheduled jobs in parallel to diagnose stuck/slow run anomalies

--- a/src/views/Pipeline.vue
+++ b/src/views/Pipeline.vue
@@ -199,7 +199,7 @@
                         <ion-icon slot="start" :icon="cloudUploadOutline" color="secondary" />
                         <ion-label>
                           {{ translate("High-Priority Queue") }}
-                          <p>{{ mapHighPriorityCount }} {{ translate("Total Files") }}</p>
+                          <p>{{ highPriorityPendingCount }} {{ translate("Pending Files") }}</p>
                         </ion-label>
                       </ion-item>
                       <div class="arrow-container">
@@ -209,7 +209,7 @@
                         <ion-icon slot="start" :icon="cloudUploadOutline" color="medium" />
                         <ion-label>
                           {{ translate("Standard Queue") }}
-                          <p>{{ mapStandardCount }} {{ translate("Total Files") }}</p>
+                          <p>{{ standardPendingCount }} {{ translate("Pending Files") }}</p>
                         </ion-label>
                       </ion-item>
                     </div>
@@ -225,7 +225,7 @@
                         <ion-icon slot="start" :icon="documentOutline" color="success" />
                         <ion-label>
                           {{ translate("Inbound Queue") }}
-                          <p>{{ mapInboundCount }} {{ translate("Total Inbound") }}</p>
+                          <p>{{ incomingPendingCount }} {{ translate("Queued Inbound") }}</p>
                         </ion-label>
                       </ion-item>
                       <div class="arrow-container">
@@ -235,7 +235,7 @@
                         <ion-icon slot="start" :icon="cloudDownloadOutline" color="primary" />
                         <ion-label>
                           {{ translate("Outbound Queue") }}
-                          <p>{{ mapOutboundCount }} {{ translate("Total Outbound") }}</p>
+                          <p>{{ outgoingPendingCount }} {{ translate("Queued Outbound") }}</p>
                         </ion-label>
                       </ion-item>
                     </div>
@@ -517,7 +517,7 @@ import {
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { DateTime } from "luxon";
 import router from "@/router";
-import { translate, emitter, api } from "@common";
+import { translate, emitter } from "@common";
 import { useJobStore } from "@/store/jobs";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useMdmConfigStore } from "@/store/mdmConfig";
@@ -708,28 +708,15 @@ const getLogPriority = (log: any) => {
 const highPriorityLogs = computed(() => logs.value.filter((log: any) => getLogPriority(log) > 6));
 const standardLogs = computed(() => logs.value.filter((log: any) => getLogPriority(log) <= 6));
 
-// KPI chip counts — pending/queued status only, match what linked pages show
-const highPriorityPendingCount = ref(0);
-const standardPendingCount = ref(0);
-const incomingPendingCount = ref(0);
-const outgoingPendingCount = ref(0);
+// Queue Depths (Pending / Queued / Running)
+const highPriorityPendingCount = computed(() => highPriorityLogs.value.filter((log: any) => ['DmlsPending', 'DmlsQueued', 'DmlsRunning'].includes(log.statusId)).length);
+const standardPendingCount = computed(() => standardLogs.value.filter((log: any) => ['DmlsPending', 'DmlsQueued', 'DmlsRunning'].includes(log.statusId)).length);
 
-// Queue Operations Map totals — read from store (matches what the linked pages show as their top-level count)
-// Note: the backend does not support priority or isOutgoing as server-side filters, so
-// we fetch a large batch and filter client-side just like the detail pages do.
-const mapHighPriorityCount = ref(0);
-const mapStandardCount = ref(0);
-const mapInboundCount = ref(0);
-const mapOutboundCount = ref(0);
-
-// KPI chip counts — finished status, fetched from API
-const highPrioritySuccessCount = ref(0);
-const standardSuccessCount = ref(0);
+// Ingestion throughput in latest 50
+const highPrioritySuccessCount = computed(() => highPriorityLogs.value.filter((log: any) => log.statusId === 'DmlsFinished').length);
+const standardSuccessCount = computed(() => standardLogs.value.filter((log: any) => log.statusId === 'DmlsFinished').length);
 const highPriorityFailedCount = computed(() => highPriorityLogs.value.filter((log: any) => ['DmlsCrashed', 'DmlsFailed'].includes(log.statusId) || (log.statusId === 'DmlsFinished' && Number(log.failedRecordCount || 0) > 0)).length);
 const standardFailedCount = computed(() => standardLogs.value.filter((log: any) => ['DmlsCrashed', 'DmlsFailed'].includes(log.statusId) || (log.statusId === 'DmlsFinished' && Number(log.failedRecordCount || 0) > 0)).length);
-// KPI chip counts — consumed/sent messages, fetched from API
-const incomingSuccessCount = ref(0);
-const outgoingSuccessCount = ref(0);
 
 // Ingestion Average Processing Time (Luxon end date - start date)
 const getAvgProcessingTime = (logsList: any[]) => {
@@ -770,10 +757,14 @@ const systemMessages = computed(() => systemMessageStore.getSystemMessages);
 const incomingMessages = computed(() => systemMessages.value.filter((msg: any) => msg.isOutgoing !== 'Y'));
 const outgoingMessages = computed(() => systemMessages.value.filter((msg: any) => msg.isOutgoing === 'Y'));
 
-// Incoming Stats (error count from local 50-item page)
+// Incoming Stats
+const incomingPendingCount = computed(() => incomingMessages.value.filter((msg: any) => ['SmsgProduced', 'SmsgCreated', 'SmsgSending'].includes(msg.statusId) && !(msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
+const incomingSuccessCount = computed(() => incomingMessages.value.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId)).length);
 const incomingErrorCount = computed(() => incomingMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
 
-// Outgoing Stats (error count from local 50-item page)
+// Outgoing Stats
+const outgoingPendingCount = computed(() => outgoingMessages.value.filter((msg: any) => ['SmsgProduced', 'SmsgCreated', 'SmsgSending'].includes(msg.statusId) && !(msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
+const outgoingSuccessCount = computed(() => outgoingMessages.value.filter((msg: any) => ['SmsgSent', 'SmsgConsumed', 'SmsgConfirmed'].includes(msg.statusId)).length);
 const outgoingErrorCount = computed(() => outgoingMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)).length);
 
 const erroredMessages = computed(() => systemMessages.value.filter((msg: any) => msg.statusId === 'SmsgError' || (msg.statusId === 'SmsgProduced' && Number(msg.failCount) > 0)));
@@ -936,65 +927,6 @@ const cancelDataManagerLog = async (configId: string, logId: string) => {
   }
 };
 
-const fetchQueueCounts = async () => {
-  const pendingStatuses = "DmlsPending,DmlsQueued,DmlsRunning";
-  const moquiStatuses = "DmlsCancelled,DmlsCrashed,DmlsFailed,DmlsFinished,DmlsPending,DmlsQueued,DmlsRunning";
-  
-  try {
-    const [
-      pendingLogsResp,
-      finishedLogsResp,
-      allLogsResp,
-      producedMsgsResp,
-      consumedMsgsResp,
-      sentMsgsResp,
-      allMsgsResp
-    ] = await Promise.all([
-      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: pendingStatuses, statusId_op: "in" } }),
-      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: "DmlsFinished" } }),
-      api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: moquiStatuses, statusId_op: "in" } }),
-      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgProduced" } }),
-      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgConsumed" } }),
-      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0, statusId: "SmsgSent" } }),
-      api({ url: "admin/systemMessages", method: "get", params: { pageSize: 500, pageIndex: 0 } })
-    ]);
-
-    const getLogPriority = (log: any) => {
-      const config = mdmStore.getConfigs.find((c: any) => c.configId === log.configId);
-      return config?.priority ? Number(config.priority) : 0;
-    };
-
-    const pendingLogs = pendingLogsResp.data?.dataManagerLogs || [];
-    highPriorityPendingCount.value = pendingLogs.filter((log: any) => getLogPriority(log) > 6).length;
-    standardPendingCount.value = pendingLogs.filter((log: any) => getLogPriority(log) <= 6).length;
-
-    const finishedLogs = finishedLogsResp.data?.dataManagerLogs || [];
-    highPrioritySuccessCount.value = finishedLogs.filter((log: any) => getLogPriority(log) > 6).length;
-    standardSuccessCount.value = finishedLogs.filter((log: any) => getLogPriority(log) <= 6).length;
-
-    const allLogs = allLogsResp.data?.dataManagerLogs || [];
-    mapHighPriorityCount.value = allLogs.filter((log: any) => getLogPriority(log) > 6).length;
-    mapStandardCount.value = allLogs.filter((log: any) => getLogPriority(log) <= 6).length;
-
-    const producedMsgs = producedMsgsResp.data?.systemMessages || [];
-    incomingPendingCount.value = producedMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
-    outgoingPendingCount.value = producedMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
-
-    const consumedMsgs = consumedMsgsResp.data?.systemMessages || [];
-    incomingSuccessCount.value = consumedMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
-
-    const sentMsgs = sentMsgsResp.data?.systemMessages || [];
-    outgoingSuccessCount.value = sentMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
-
-    const allMsgs = allMsgsResp.data?.systemMessages || [];
-    mapInboundCount.value = allMsgs.filter((msg: any) => msg.isOutgoing === 'N').length;
-    mapOutboundCount.value = allMsgs.filter((msg: any) => msg.isOutgoing === 'Y').length;
-
-  } catch (err) {
-    console.error("Failed to fetch queue counts", err);
-  }
-};
-
 const refreshData = async () => {
   isLoading.value = true;
   try {
@@ -1005,8 +937,7 @@ const refreshData = async () => {
       mdmStore.fetchDataManagerLogs({ pageSize: 50 }),
       mdmStore.fetchConfigs(),
       utilStore.fetchStatusItemsByType("SystemMessage"),
-      utilStore.fetchStatusItemsByType("DataManagerLog"),
-      fetchQueueCounts()
+      utilStore.fetchStatusItemsByType("DataManagerLog")
     ]);
 
     // Fetch run history for active scheduled jobs in parallel to diagnose stuck/slow run anomalies

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -235,7 +235,7 @@ const loadMessages = async () => {
   const payload = {
     pageIndex: isDirectionFiltered ? 0 : pageIndex.value,
     pageSize: isDirectionFiltered ? 500 : PAGE_SIZE,
-  } as Record<string, any>
+  } as Record<string, any>;
 
   if(queryString.value.trim()) {
     payload["queryString"] = queryString.value.trim()
@@ -302,7 +302,11 @@ watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, sele
   await loadMessages();
 });
 
-watch(pageIndex, loadMessages);
+watch(pageIndex, () => {
+  if (!selectedIsOutgoing.value) {
+    loadMessages();
+  }
+});
 
 onIonViewWillEnter(async () => {
   await Promise.all([

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -19,73 +19,110 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatusId"
-                @ionChange="selectedStatusId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="status in statuses"
-                  :key="status.statusId"
-                  :value="status.statusId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Status')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedStatusId"
+                  @ionChange="selectedStatusId = $event.detail.value"
                 >
-                  {{ status.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="status in statuses"
+                    :key="status.statusId"
+                    :value="status.statusId"
+                  >
+                    {{ status.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedStatusId" fill="clear" class="clear-filter-btn" @click="selectedStatusId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Parent Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedParentTypeId"
-                @ionChange="handleParentTypeChange($event)"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="parent in parentTypes"
-                  :key="parent.id"
-                  :value="parent.id"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Parent Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedParentTypeId"
+                  @ionChange="handleParentTypeChange($event)"
                 >
-                  {{ parent.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="parent in parentTypes"
+                    :key="parent.id"
+                    :value="parent.id"
+                  >
+                    {{ parent.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedParentTypeId" fill="clear" class="clear-filter-btn" @click="selectedParentTypeId = ''; selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Message Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedTypeId"
-                @ionChange="selectedTypeId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="type in filteredTypes"
-                  :key="type.systemMessageTypeId"
-                  :value="type.systemMessageTypeId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Message Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedTypeId"
+                  @ionChange="selectedTypeId = $event.detail.value"
                 >
-                  {{ type.description || type.systemMessageTypeId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="type in filteredTypes"
+                    :key="type.systemMessageTypeId"
+                    :value="type.systemMessageTypeId"
+                  >
+                    {{ type.description || type.systemMessageTypeId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedTypeId" fill="clear" class="clear-filter-btn" @click="selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Remote System')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedRemoteId"
-                @ionChange="selectedRemoteId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="remote in remotes"
-                  :key="remote.systemMessageRemoteId"
-                  :value="remote.systemMessageRemoteId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Remote System')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedRemoteId"
+                  @ionChange="selectedRemoteId = $event.detail.value"
                 >
-                  {{ remote.description || remote.systemMessageRemoteId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="remote in remotes"
+                    :key="remote.systemMessageRemoteId"
+                    :value="remote.systemMessageRemoteId"
+                  >
+                    {{ remote.description || remote.systemMessageRemoteId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedRemoteId" fill="clear" class="clear-filter-btn" @click="selectedRemoteId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
+
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Direction')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedIsOutgoing"
+                  @ionChange="selectedIsOutgoing = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option value="N">{{ translate("Inbound") }}</ion-select-option>
+                  <ion-select-option value="Y">{{ translate("Outbound") }}</ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedIsOutgoing" fill="clear" class="clear-filter-btn" @click="selectedIsOutgoing = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>
@@ -94,7 +131,19 @@
           <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
-          <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
+          <div class="page-input">
+            <span>{{ translate("Page") }}</span>
+            <input
+              type="number"
+              min="1"
+              :max="pageCount"
+              :value="pageIndex + 1"
+              @keyup="validatePageInput($event)"
+              @change="goToPage($event)"
+              class="page-number-input"
+            />
+            <span>/ {{ pageCount }}</span>
+          </div>
           <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
@@ -115,8 +164,8 @@ import {
   IonCardContent,
   IonContent,
   IonHeader,
+  IonIcon,
   IonMenuButton,
-  IonNote,
   IonPage,
   IonSearchbar,
   IonSelect,
@@ -127,6 +176,7 @@ import {
 } from "@ionic/vue";
 import { computed, ref, watch } from "vue";
 import { translate } from "@common";
+import { closeCircleOutline } from "ionicons/icons";
 import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useUtilStore } from "@/store/util";
@@ -143,15 +193,34 @@ const selectedStatusId = ref("");
 const selectedTypeId = ref("");
 const selectedParentTypeId = ref("");
 const selectedRemoteId = ref("");
+const selectedIsOutgoing = ref("");
 const pageIndex = ref(0);
 
-const messages = computed(() => store.getSystemMessages);
+// When direction filter is active, all fetched records are filtered client-side
+const filteredMessages = computed(() => {
+  const all = store.getSystemMessages;
+  if (!selectedIsOutgoing.value) return all;
+  return all.filter((msg: any) => msg.isOutgoing === selectedIsOutgoing.value);
+});
+
+// Paginated slice of filteredMessages
+const messages = computed(() => {
+  if (!selectedIsOutgoing.value) return filteredMessages.value; // server already paginates
+  const start = pageIndex.value * PAGE_SIZE;
+  return filteredMessages.value.slice(start, start + PAGE_SIZE);
+});
+
 const total = computed(() => store.getSystemMessageTotal);
 const types = computed(() => store.getSystemMessageTypes);
 const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
-const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const pageCount = computed(() => {
+  if (selectedIsOutgoing.value) {
+    return Math.max(Math.ceil(filteredMessages.value.length / PAGE_SIZE), 1);
+  }
+  return Math.max(Math.ceil(total.value / PAGE_SIZE), 1);
+});
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -159,9 +228,13 @@ const filteredTypes = computed(() => {
 });
 
 const loadMessages = async () => {
+  // When direction filter is active, fetch a large batch for client-side pagination
+  // (the API does not support isOutgoing as a server-side filter)
+  const isDirectionFiltered = !!selectedIsOutgoing.value;
+
   const payload = {
-    pageIndex: pageIndex.value,
-    pageSize: PAGE_SIZE,
+    pageIndex: isDirectionFiltered ? 0 : pageIndex.value,
+    pageSize: isDirectionFiltered ? 500 : PAGE_SIZE,
   } as Record<string, any>
 
   if(queryString.value.trim()) {
@@ -208,7 +281,23 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
-watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId], async () => {
+const validatePageInput = (event: any) => {
+  const value = parseInt(event.target.value);
+  if (value > pageCount.value) {
+    event.target.value = pageCount.value;
+  }
+};
+
+const goToPage = (event: any) => {
+  const newPage = parseInt(event.target.value);
+  if (newPage && newPage > 0 && newPage <= pageCount.value) {
+    pageIndex.value = newPage - 1;
+  } else {
+    event.target.value = pageIndex.value + 1;
+  }
+};
+
+watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId, selectedIsOutgoing], async () => {
   resetToFirstPage();
   await loadMessages();
 });
@@ -216,21 +305,46 @@ watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, sele
 watch(pageIndex, loadMessages);
 
 onIonViewWillEnter(async () => {
-  if (route.query?.statusId) {
-    selectedStatusId.value = route.query.statusId as string;
-  } else {
-    selectedStatusId.value = "";
-  }
   await Promise.all([
     store.fetchSystemMessageTypes(),
     store.fetchSystemMessageRemotes(),
     store.fetchSystemMessageStatusMetadata()
   ]);
+
+  const currentQuery = router.currentRoute.value.query;
+  selectedStatusId.value = (currentQuery?.statusId as string) ?? "";
+  selectedIsOutgoing.value = (currentQuery?.isOutgoing as string) ?? "";
+
   await loadMessages();
 });
 </script>
 
 <style scoped>
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacer-lg, 16px);
+}
+
+.filter-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-item ion-select {
+  flex: 1;
+}
+
+.clear-filter-btn {
+  --padding-start: 6px;
+  --padding-end: 6px;
+  flex-shrink: 0;
+  margin-inline-start: 4px;
+  height: 36px;
+  width: 36px;
+}
 
 .results-header {
   display: flex;
@@ -246,5 +360,29 @@ onIonViewWillEnter(async () => {
   align-items: center;
   gap: 12px;
   padding: 16px;
+}
+
+.page-input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-sm, 8px);
+}
+
+.page-number-input {
+  width: 50px;
+  text-align: center;
+  border: 1px solid var(--ion-color-medium);
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.page-number-input::-webkit-outer-spin-button,
+.page-number-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.page-number-input[type=number] {
+  -moz-appearance: textfield;
 }
 </style>

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -198,31 +198,15 @@ const selectedIsOutgoing = ref("");
 const pageIndex = ref(0);
 const isInitialLoading = ref(true);
 
-// When direction filter is active, all fetched records are filtered client-side
-const filteredMessages = computed(() => {
-  const all = store.getSystemMessages;
-  if (!selectedIsOutgoing.value) return all;
-  return all.filter((msg: any) => msg.isOutgoing === selectedIsOutgoing.value);
-});
-
-// Paginated slice of filteredMessages
-const messages = computed(() => {
-  if (!selectedIsOutgoing.value) return filteredMessages.value; // server already paginates
-  const start = pageIndex.value * PAGE_SIZE;
-  return filteredMessages.value.slice(start, start + PAGE_SIZE);
-});
+const messages = computed(() => store.getSystemMessages);
 
 const total = computed(() => store.getSystemMessageTotal);
 const types = computed(() => store.getSystemMessageTypes);
 const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
-const pageCount = computed(() => {
-  if (selectedIsOutgoing.value) {
-    return Math.max(Math.ceil(filteredMessages.value.length / PAGE_SIZE), 1);
-  }
-  return Math.max(Math.ceil(total.value / PAGE_SIZE), 1);
-});
+const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const isLoading = computed(() => isInitialLoading.value || store.isFetchingMessages);
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -230,13 +214,9 @@ const filteredTypes = computed(() => {
 });
 
 const loadMessages = async () => {
-  // When direction filter is active, fetch a large batch for client-side pagination
-  // (the API does not support isOutgoing as a server-side filter)
-  const isDirectionFiltered = !!selectedIsOutgoing.value;
-
   const payload = {
-    pageIndex: isDirectionFiltered ? 0 : pageIndex.value,
-    pageSize: isDirectionFiltered ? 500 : PAGE_SIZE,
+    pageIndex: pageIndex.value,
+    pageSize: PAGE_SIZE,
   } as Record<string, any>;
 
   if(queryString.value.trim()) {
@@ -315,6 +295,7 @@ watch(pageIndex, () => {
 });
 
 onIonViewWillEnter(async () => {
+  isInitialLoading.value = true;
   await Promise.all([
     store.fetchSystemMessageTypes(),
     store.fetchSystemMessageRemotes(),
@@ -326,6 +307,7 @@ onIonViewWillEnter(async () => {
   selectedIsOutgoing.value = (currentQuery?.isOutgoing as string) ?? "";
 
   await loadMessages();
+  isInitialLoading.value = false;
 });
 </script>
 

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -178,7 +178,6 @@ import {
 import { closeCircleOutline } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import { translate } from "@common";
-import { closeCircleOutline } from "ionicons/icons";
 import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { useUtilStore } from "@/store/util";


### PR DESCRIPTION
### Related Issues

Closes  #1014 

### Short Description and Why It's Useful

This PR resolves cross-page navigation filtering issues between the Job Manager Dashboard and the File/Message History pages, and unifies the UI and pagination logic. 

**Key Changes:**

* **Dashboard Navigation Fix:** Ensures query parameters (e.g., `?priority=HIGH` or `?isOutgoing=N`) passed from Dashboard KPI cards correctly initialize and apply filters in `onIonViewWillEnter` upon loading the target history pages. Solved race conditions by moving state assignments after initial metadata fetches.

* **Hybrid Pagination for Client-Side Filtering:** Since `isOutgoing` is not supported as a server-side filter, the System Message Monitor now fetches a larger batch (500 records) when a direction filter is active. It performs client-side filtering and pagination locally against this batch to ensure page counts are accurate and prevent empty pages. 

* **Unified UI & UX:** Updated the System Message Monitor filter grid to match the File History page:
    * Implemented a responsive single-row flex grid for all filter dropdowns.
    * Added conditional "Clear" (close circle) buttons that appear only when a filter is active.
    * Replaced static pagination text with an editable page number input field, allowing users to jump directly to specific pages.
