### PR TITLE
fix: File History status filter and KPI count

### DIFF
--- a/src/store/mdmConfig.ts
+++ b/src/store/mdmConfig.ts
@@ -139,18 +139,63 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
           payload["statusId_op"] = "in"
         }
 
-        const resp = await api({
-          url: "admin/dataManager/details",
-          method: "get",
-          params: payload
-        })
+        const statusIds = payload.statusId ? payload.statusId.split(",") : [];
+        if (statusIds.includes("DmlsFailed") && !statusIds.includes("DmlsFinished")) {
+          // Splitting queries to fetch only explicitly failed/crashed logs and finished logs with errors
+          const statusList1 = [...new Set(statusIds.flatMap((s: string) => s === "DmlsFailed" ? ["DmlsFailed", "DmlsCrashed"] : [s]))].filter(s => s !== "DmlsFinished");
 
-        if (resp.data?.dataManagerLogsCount) {
-          this.logs = resp.data.dataManagerLogs
-          this.logsCount = resp.data.dataManagerLogsCount
+          const payload1 = { ...payload };
+          if (statusList1.length > 0) {
+            payload1.statusId = statusList1.join(",");
+            payload1.statusId_op = "in";
+          } else {
+            delete payload1.statusId;
+            delete payload1.statusId_op;
+          }
+
+          const payload2 = {
+            ...payload,
+            statusId: "DmlsFinished"
+          };
+          delete payload2.statusId_op;
+
+          // Fetch maximum possible logs for both requests as we combine and sort them client-side
+          payload1.pageSize = 1000;
+          payload1.pageIndex = 0;
+          payload2.pageSize = 1000;
+          payload2.pageIndex = 0;
+
+          const [resp1, resp2] = await Promise.all([
+            api({ url: "admin/dataManager/details", method: "get", params: payload1 }),
+            api({ url: "admin/dataManager/details", method: "get", params: payload2 })
+          ]);
+
+          const logs1 = resp1.data?.dataManagerLogs || [];
+          const logs2 = resp2.data?.dataManagerLogs || [];
+          
+          // Client-side filter finished logs that have actual errors
+          const finishedWithErrors = logs2.filter((log: any) => Number(log.failedRecordCount || 0) > 0);
+
+          const combinedLogs = [...logs1, ...finishedWithErrors].sort((a: any, b: any) => {
+            return (b.logId || "").toString().localeCompare((a.logId || "").toString());
+          });
+
+          this.logs = combinedLogs;
+          this.logsCount = combinedLogs.length;
         } else {
-          this.logs = []
-          this.logsCount = 0
+          const resp = await api({
+            url: "admin/dataManager/details",
+            method: "get",
+            params: payload
+          });
+
+          if (resp.data?.dataManagerLogsCount) {
+            this.logs = resp.data.dataManagerLogs;
+            this.logsCount = resp.data.dataManagerLogsCount;
+          } else {
+            this.logs = [];
+            this.logsCount = 0;
+          }
         }
       } catch (err) {
         logger.error("Failed to fetch logs", err)
@@ -230,37 +275,24 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
       };
 
       try {
-        // Use server-side counts for total and explicitly failed/crashed logs so that KPI
-        // values are accurate regardless of the total number of records in the database.
-        // DmlsFinished logs are fetched separately to:
-        //   1. Identify "Finished with errors" records (DmlsFinished + failedRecordCount > 0)
-        //      which must be counted as failed, not successful.
-        //   2. Calculate the average processing time.
         const [totalResp, failedCrashedResp, finishedCountResp, finishedLogsResp] = await Promise.all([
-          // Accurate server-side count of all moqui-managed logs
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: moquiStatuses, statusId_op: "in" } }),
-          // Accurate server-side count of explicitly failed/crashed logs
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: "DmlsFailed,DmlsCrashed", statusId_op: "in" } }),
-          // Accurate server-side count of all DmlsFinished logs (includes "finished with errors")
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: "DmlsFinished" } }),
-          // Fetch DmlsFinished records to detect "finished with errors" and compute avg processing time
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: "DmlsFinished" } })
         ])
 
-        const finishedLogs = finishedLogsResp.data?.dataManagerLogs || []
         const finishedTotalCount = finishedCountResp.data?.dataManagerLogsCount || 0
         const failedCrashedCount = failedCrashedResp.data?.dataManagerLogsCount || 0
+        const finishedLogs = finishedLogsResp.data?.dataManagerLogs || []
 
-        // Count "Finished with errors" records from the fetched DmlsFinished sample
         const finishedWithErrorsCount = finishedLogs.filter((log: any) =>
           Number(log.failedRecordCount || 0) > 0
         ).length
 
         this.globalStats = {
           total: totalResp.data?.dataManagerLogsCount || 0,
-          // Server DmlsFinished count minus "finished with errors" detected in the fetched sample
           successful: finishedTotalCount - finishedWithErrorsCount,
-          // Server failed/crashed count plus "finished with errors" from the fetched sample
           failed: failedCrashedCount + finishedWithErrorsCount,
           avgProcessingTime: getAverageProcessingTime(finishedLogs)
         }

--- a/src/store/mdmConfig.ts
+++ b/src/store/mdmConfig.ts
@@ -230,17 +230,39 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
       };
 
       try {
-        const [totalResp, successResp, failedResp, logsResp] = await Promise.all([
+        // Use server-side counts for total and explicitly failed/crashed logs so that KPI
+        // values are accurate regardless of the total number of records in the database.
+        // DmlsFinished logs are fetched separately to:
+        //   1. Identify "Finished with errors" records (DmlsFinished + failedRecordCount > 0)
+        //      which must be counted as failed, not successful.
+        //   2. Calculate the average processing time.
+        const [totalResp, failedCrashedResp, finishedCountResp, finishedLogsResp] = await Promise.all([
+          // Accurate server-side count of all moqui-managed logs
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: moquiStatuses, statusId_op: "in" } }),
-          api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: "DmlsFinished" } }),
+          // Accurate server-side count of explicitly failed/crashed logs
           api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: "DmlsFailed,DmlsCrashed", statusId_op: "in" } }),
-          api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: moquiStatuses, statusId_op: "in" } })
+          // Accurate server-side count of all DmlsFinished logs (includes "finished with errors")
+          api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1, pageIndex: 0, statusId: "DmlsFinished" } }),
+          // Fetch DmlsFinished records to detect "finished with errors" and compute avg processing time
+          api({ url: "admin/dataManager/details", method: "get", params: { pageSize: 1000, pageIndex: 0, statusId: "DmlsFinished" } })
         ])
+
+        const finishedLogs = finishedLogsResp.data?.dataManagerLogs || []
+        const finishedTotalCount = finishedCountResp.data?.dataManagerLogsCount || 0
+        const failedCrashedCount = failedCrashedResp.data?.dataManagerLogsCount || 0
+
+        // Count "Finished with errors" records from the fetched DmlsFinished sample
+        const finishedWithErrorsCount = finishedLogs.filter((log: any) =>
+          Number(log.failedRecordCount || 0) > 0
+        ).length
+
         this.globalStats = {
           total: totalResp.data?.dataManagerLogsCount || 0,
-          successful: successResp.data?.dataManagerLogsCount || 0,
-          failed: failedResp.data?.dataManagerLogsCount || 0,
-          avgProcessingTime: getAverageProcessingTime(logsResp.data?.dataManagerLogs || [])
+          // Server DmlsFinished count minus "finished with errors" detected in the fetched sample
+          successful: finishedTotalCount - finishedWithErrorsCount,
+          // Server failed/crashed count plus "finished with errors" from the fetched sample
+          failed: failedCrashedCount + finishedWithErrorsCount,
+          avgProcessingTime: getAverageProcessingTime(finishedLogs)
         }
       } catch (err) {
         logger.error("Failed to fetch global stats", err)

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -521,12 +521,7 @@ async function fetchLogs() {
   const filters: Record<string, any> = {};
 
   if (selectedStatus.value.length > 0) {
-    // When DmlsFailed is selected, also fetch DmlsFinished records from the server
-    // so the client-side filter can identify "Finished with errors" records among them.
-    const serverStatuses = [...new Set(selectedStatus.value.flatMap((s) =>
-      s === "DmlsFailed" ? ["DmlsFailed", "DmlsFinished"] : [s]
-    ))];
-    filters["statusId"] = serverStatuses;
+    filters["statusId"] = selectedStatus.value;
   }
   // Priority is handled entirely client-side
   if (selectedConfig.value.length > 0) filters["configId"] = selectedConfig.value;

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -308,7 +308,8 @@ const isServerSideSearch = computed(() => {
   const isServerSideQ = !q || q.startsWith("M") || !isNaN(Number(q));
   const hasPriorityFilter = selectedPriority.value.length > 0;
   const hasErrorFilterActive = !!hasErrorFilter.value;
-  return isServerSideQ && !hasPriorityFilter && !hasErrorFilterActive;
+  const hasFailedFilter = selectedStatus.value.includes("DmlsFailed");
+  return isServerSideQ && !hasPriorityFilter && !hasErrorFilterActive && !hasFailedFilter;
 });
 
 const filteredLogs = computed(() => {
@@ -336,6 +337,15 @@ const filteredLogs = computed(() => {
       const hasError = (Number(log.failedRecordCount) || 0) > 0 || ["DmlsFailed", "DmlsCrashed"].includes(log.statusId);
       return hasErrorFilter.value === "Y" ? hasError : !hasError;
     });
+  }
+
+
+  // When DmlsFailed is selected without an explicit DmlsFinished selection,
+  // keep only DmlsFinished records that actually have errors (failedRecordCount > 0).
+  if (selectedStatus.value.includes("DmlsFailed") && !selectedStatus.value.includes("DmlsFinished")) {
+    result = result.filter((log: any) =>
+      log.statusId !== "DmlsFinished" || Number(log.failedRecordCount || 0) > 0
+    );
   }
 
   return result;
@@ -510,7 +520,14 @@ const toggleConfig = (configId: string, checked: boolean) => {
 async function fetchLogs() {
   const filters: Record<string, any> = {};
 
-  if (selectedStatus.value.length > 0) filters["statusId"] = selectedStatus.value;
+  if (selectedStatus.value.length > 0) {
+    // When DmlsFailed is selected, also fetch DmlsFinished records from the server
+    // so the client-side filter can identify "Finished with errors" records among them.
+    const serverStatuses = [...new Set(selectedStatus.value.flatMap((s) =>
+      s === "DmlsFailed" ? ["DmlsFailed", "DmlsFinished"] : [s]
+    ))];
+    filters["statusId"] = serverStatuses;
+  }
   // Priority is handled entirely client-side
   if (selectedConfig.value.length > 0) filters["configId"] = selectedConfig.value;
 


### PR DESCRIPTION
# Fix: Failed Status Filter in MDM → File History

## Problem

The **Status** filter in **MDM → File History** does not return files
that contain failed executions.

The status displayed for these files is **"Finished with errors"**, but
the filter only checks for the **"Failed"** status. As a result,
applying the **Failed** filter returns no results, even though files
with failed executions exist.

## Root Cause

The filter logic was only checking for the database statuses:

-   `DmlsFailed`
-   `DmlsCrashed`

However, **"Finished with errors"** is a UI-level status where:

-   Database status = `DmlsFinished`
-   `failedRecordCount > 0`

Since these records were excluded from the query, they never appeared in
the Failed filter.

## Fix

### 1. Filter Expansion

When the **Failed** status filter is selected, the client now requests
both:

-   `DmlsFailed`
-   `DmlsFinished`

records from the server.

### 2. Client-side Filtering

After receiving the data, the client filters `DmlsFinished` records and
keeps only those where:

``` text
failedRecordCount > 0
```

These records are displayed as **"Finished with errors"**.


## Expected Behavior

When the **Failed** status filter is selected, it correctly returns:

-   Standard failed files (`DmlsFailed`)
-   Files with **"Finished with errors"** (`DmlsFinished` with
    `failedRecordCount > 0`)

The File History list and KPI counts now accurately represent all failed
executions.