### PR TITLE
fix: Job Run History dashboard counts, user filter, and pagination

### DIFF
--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -15,7 +15,10 @@ const getRunStatus = (run: any) => {
 
 const getRunHistoryStats = (runs: Array<any>) => runs.reduce((stats: any, run: any) => {
   stats.total += 1;
-  stats[run.runStatus] += 1;
+  const statusKey = String(run.runStatus || "").toLowerCase();
+  if (statusKey in stats) {
+    stats[statusKey] += 1;
+  }
   return stats;
 }, {
   total: 0,
@@ -70,6 +73,7 @@ export const useJobStore = defineStore("job", {
       running: 0,
       terminated: 0
     },
+    allJobRuns: [] as Array<any>,
     loading: false
   }),
   getters: {
@@ -331,38 +335,45 @@ export const useJobStore = defineStore("job", {
         const hasErrors = payload.hasError || "";
         const selectedProductStoreId = useUserStore().getCurrentProductStore?.productStoreId || "";
 
-        let jobsToLoad = selectedJobName
-          ? this.jobs.filter((job: any) => job.jobName === selectedJobName)
-          : this.jobs;
+        let runs = [] as any;
 
-        const productIds = [...new Set(jobsToLoad.map((job: any) => job.instanceOfProductId).filter(Boolean))] as string[];
-        await Promise.all(productIds
-          .filter((productId: string) => !this.products[productId])
-          .map((productId: string) => this.fetchProductDetail(productId))
-        );
+        if (payload.fetchFromServer !== false) {
+          const jobsToLoad = selectedJobName
+            ? this.jobs.filter((job: any) => job.jobName === selectedJobName)
+            : this.jobs;
 
-        const runResponses = await Promise.allSettled(
-          jobsToLoad.map(async (job: any) => {
-            const params = { pageSize: runsPerJob, pageIndex: 0 } as any;
-            if (hasErrors === "Y") params.hasError = "Y";
-            const runs = await this.fetchJobRuns(job.jobName, params);
-            return runs.map((run: any) => ({
-              ...run,
-              jobName: job.jobName,
-              serviceName: job.serviceName,
-              jobDescription: job.description,
-              systemJobEnumId: job.systemJobEnumId,
-              instanceOfProductId: job.instanceOfProductId,
-              jobProductStoreId: getProductStoreIdFromParameters(job.serviceJobParameters),
-              productName: this.products[job.instanceOfProductId]?.productName,
-              paused: job.paused,
-              cronExpression: job.cronExpression,
-              runStatus: getRunStatus(run)
-            }));
-          })
-        );
+          const productIds = [...new Set(jobsToLoad.map((job: any) => job.instanceOfProductId).filter(Boolean))] as string[];
+          await Promise.all(productIds
+            .filter((productId: string) => !this.products[productId])
+            .map((productId: string) => this.fetchProductDetail(productId))
+          );
 
-        let runs = runResponses.flatMap((result: any) => result.status === "fulfilled" ? result.value : []);
+          const runResponses = await Promise.allSettled(
+            jobsToLoad.map(async (job: any) => {
+              const params = { pageSize: runsPerJob, pageIndex: 0 } as any;
+              if (hasErrors === "Y") params.hasError = "Y";
+              const runs = await this.fetchJobRuns(job.jobName, params);
+              return runs.map((run: any) => ({
+                ...run,
+                jobName: job.jobName,
+                serviceName: job.serviceName,
+                jobDescription: job.description,
+                systemJobEnumId: job.systemJobEnumId,
+                instanceOfProductId: job.instanceOfProductId,
+                jobProductStoreId: getProductStoreIdFromParameters(job.serviceJobParameters),
+                productName: this.products[job.instanceOfProductId]?.productName,
+                paused: job.paused,
+                cronExpression: job.cronExpression,
+                runStatus: getRunStatus(run)
+              }));
+            })
+          );
+
+          runs = runResponses.flatMap((result: any) => result.status === "fulfilled" ? result.value : []);
+          this.allJobRuns = runs;
+        } else {
+          runs = [...this.allJobRuns];
+        }
 
         if (selectedProductStoreId) {
           runs = runs.filter((run: any) => {
@@ -391,7 +402,12 @@ export const useJobStore = defineStore("job", {
         }
 
         if (selectedUserId) {
-          runs = runs.filter((run: any) => String(run.userId || "").toLowerCase().includes(String(selectedUserId).toLowerCase()));
+          const userStore = useUserStore();
+          const searchVal = String(selectedUserId).toLowerCase();
+          runs = runs.filter((run: any) =>
+            String(run.userId || "").toLowerCase().includes(searchVal) ||
+            String(userStore.getUserFullName(run.userId) || "").toLowerCase().includes(searchVal)
+          );
         }
 
         if (hasErrors === "Y") {

--- a/src/views/JobRunHistory.vue
+++ b/src/views/JobRunHistory.vue
@@ -103,7 +103,20 @@
           <ion-button fill="outline" :disabled="pageIndex === 0 || isLoading" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
-          <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
+          <div class="page-input">
+            <span>{{ translate("Page") }}</span>
+            <input
+              type="number"
+              min="1"
+              :max="pageCount"
+              :value="pageIndex + 1"
+              @keyup="validatePageInput($event)"
+              @change="goToPage($event)"
+              class="page-number-input"
+              :disabled="isLoading"
+            />
+            <span>/ {{ pageCount }}</span>
+          </div>
           <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1 || isLoading" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
@@ -362,11 +375,12 @@ const handleQueryInput = (event: CustomEvent) => {
   queryString.value = (event as any).detail.value || "";
 };
 
-const loadRuns = async () => {
+const loadRuns = async (fetchFromServer = true) => {
   const payload = {
     pageIndex: pageIndex.value,
     pageSize: PAGE_SIZE,
-    runsPerJob: RUNS_PER_JOB
+    runsPerJob: RUNS_PER_JOB,
+    fetchFromServer
   } as Record<string, any>;
 
   if (queryString.value.trim()) payload.queryString = queryString.value.trim();
@@ -390,6 +404,22 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
+const validatePageInput = (event: any) => {
+  const value = parseInt(event.target.value, 10);
+  if (value > pageCount.value) {
+    event.target.value = pageCount.value;
+  }
+};
+
+const goToPage = (event: any) => {
+  const newPage = parseInt(event.target.value, 10);
+  if (newPage && newPage > 0 && newPage <= pageCount.value) {
+    pageIndex.value = newPage - 1;
+  } else {
+    event.target.value = pageIndex.value + 1;
+  }
+};
+
 const goToJob = (jobName: string) => {
   router.push({ name: "JobDetail", params: { jobName } });
 };
@@ -398,16 +428,22 @@ const goToLog = (logId: string | number) => {
   router.push({ name: "FileHistoryDetail", params: { id: logId } });
 };
 
+let isFilterResetting = false;
+
 watch([queryString, selectedStatus, selectedJobName, selectedUserId, hasDataLogs], async () => {
   if (pageIndex.value !== 0) {
+    isFilterResetting = true;
     pageIndex.value = 0;
-  } else {
-    await loadRuns();
   }
-})
+  await loadRuns(true);
+});
 
 watch(pageIndex, async () => {
-  await loadRuns();
+  if (isFilterResetting) {
+    isFilterResetting = false;
+    return;
+  }
+  await loadRuns(false);
 });
 
 onIonViewWillEnter(async () => {
@@ -490,5 +526,27 @@ onIonViewWillEnter(async () => {
   .pagination {
     justify-content: stretch;
   }
+}
+.page-input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-sm);
+}
+
+.page-number-input {
+  width: 50px;
+  text-align: center;
+  border: 1px solid var(--ion-color-medium);
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.page-number-input::-webkit-outer-spin-button,
+.page-number-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.page-number-input[type=number] {
+  -moz-appearance: textfield;
 }
 </style>


### PR DESCRIPTION
Resolves multiple issues on the Job Run History page (#1018):

KPI Counts: Fixed dashboard summary counters (Successful, Failed, Running showing 0) by resolving a casing mismatch in the store reducer.

User Search: Updated the filter to search against both raw usernames and resolved user full names.
Pagination & Page Jump:

- Implemented client-side pagination on loaded runs. This speeds up page navigation and ensures the correct total page count is displayed.
- Added a direct Page Jump input box to pagination controls, matching the File History page design.
- Optimized watchers to prevent duplicate API requests on page navigation.

Verification: Updated unit tests to align with store status values. Confirmed that unit tests pass and the project builds successfully.