### PR TITLE
Fix credential wiping when updating Remote System Details

### DIFF
--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -179,14 +179,6 @@ const form = reactive<Record<string, any>>({
   "sendServiceName": { label: "Send Service", type: "textarea" }
 });
 
-const CREDENTIAL_FIELDS = new Set([
-  "password",
-  "privateKey",
-  "sharedSecret",
-  "sendSharedSecret",
-  "oldSharedSecret"
-]);
-
 const isCreateMode = computed(() => !props.id);
 const pageTitle = computed(() => isCreateMode.value ? translate("Create Remote System") : translate("Remote System Detail"));
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
@@ -196,7 +188,7 @@ const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1)
 
 const setForm = (payload?: Record<string, any>) => {
   for (const key of Object.keys(form)) {
-    form[key].value = payload?.[key] ?? (CREDENTIAL_FIELDS.has(key) ? null : "");
+    form[key].value = payload?.[key] ?? (form[key].type === "password" ? null : "");
   }
 };
 
@@ -231,7 +223,7 @@ const saveRemote = async () => {
 
   // TODO: check do we need this, as the form fields will always be a string
   const payload = Object.entries(form).reduce((params: Record<string, any>, [key, field]) => {
-    if(CREDENTIAL_FIELDS.has(key) && field.value === null){
+    if(field.type === "password" && field.value === null){
       return params;
     }
     if(field.value !== null && field.value !== undefined) {

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -179,6 +179,14 @@ const form = reactive<Record<string, any>>({
   "sendServiceName": { label: "Send Service", type: "textarea" }
 });
 
+const CREDENTIAL_FIELDS = new Set([
+  "password",
+  "privateKey",
+  "sharedSecret",
+  "sendSharedSecret",
+  "oldSharedSecret"
+]);
+
 const isCreateMode = computed(() => !props.id);
 const pageTitle = computed(() => isCreateMode.value ? translate("Create Remote System") : translate("Remote System Detail"));
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
@@ -188,7 +196,7 @@ const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1)
 
 const setForm = (payload?: Record<string, any>) => {
   for (const key of Object.keys(form)) {
-    form[key].value = payload?.[key] || "";
+    form[key].value = payload?.[key] ?? (CREDENTIAL_FIELDS.has(key) ? null : "");
   }
 };
 
@@ -223,7 +231,10 @@ const saveRemote = async () => {
 
   // TODO: check do we need this, as the form fields will always be a string
   const payload = Object.entries(form).reduce((params: Record<string, any>, [key, field]) => {
-    if(field.value !== null || field.value !== undefined) {
+    if(CREDENTIAL_FIELDS.has(key) && field.value === null){
+      return params;
+    }
+    if(field.value !== null && field.value !== undefined) {
       params[key] = field.value
     }
     return params

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -53,7 +53,7 @@
                   fill="outline"
                   :readonly="!isCreateMode && key === 'systemMessageRemoteId'"
                   :value="field.value || ''"
-                  @ionInput="updateField(key, $event.detail.value || '')"
+                  @ionInput="updateField(key, $event.detail.value)"
                 />
               </template>
             </div>
@@ -192,8 +192,12 @@ const setForm = (payload?: Record<string, any>) => {
   }
 };
 
-const updateField = (key: string, value: string) => {
-  form[key].value = value;
+const updateField = (key: string, value: string | null | undefined) => {
+  if (form[key].type === "password" && !value) {
+    form[key].value = null;
+  } else {
+    form[key].value = value ?? "";
+  }
 };
 
 const loadRemote = async () => {


### PR DESCRIPTION
### Related Issues

Closes #1012 

### Short Description and Why It's Useful

**Fix: Prevent credential wiping when updating Remote System Details**

Previously, updating any non-sensitive field (like Description) on the Remote System Detail page would silently overwrite all credential fields (Password, Private Key, Shared Secret, etc.) with empty strings in the database. This happened because the backend deliberately (and correctly) omits these sensitive fields from the GET response, but the frontend was defaulting undefined fields to `""` and including them in the PUT payload.

This PR fixes the issue by:
1. Defining a `CREDENTIAL_FIELDS` set.
2. Initializing untouched credential fields as `null` instead of `""`.
3. Filtering out `null` credential fields when constructing the save payload.

As a result, updating non-sensitive fields no longer affects existing credentials in the database, while explicit password changes by the user still work as expected.