### PR TITLE
feat: provide consistent clear filter action across Job Manager filter panels (#1026)

### DIFF
--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -332,6 +332,26 @@ ion-select {
   gap: 16px;
 }
 
+.filter-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-item ion-select,
+.filter-item ion-input {
+  flex: 1;
+}
+
+.clear-filter-btn {
+  --padding-start: 6px;
+  --padding-end: 6px;
+  flex-shrink: 0;
+  margin-inline-start: 4px;
+  height: 36px;
+  width: 36px;
+}
+
 .catalog-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));

--- a/src/views/DataDocumentCatalog.vue
+++ b/src/views/DataDocumentCatalog.vue
@@ -25,31 +25,41 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Primary Entity')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedEntity"
-                @ionChange="selectedEntity = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All entities") }}</ion-select-option>
-                <ion-select-option v-for="entity in primaryEntities" :key="entity" :value="entity">
-                  {{ entity }}
-                </ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Primary Entity')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedEntity"
+                  @ionChange="selectedEntity = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All entities") }}</ion-select-option>
+                  <ion-select-option v-for="entity in primaryEntities" :key="entity" :value="entity">
+                    {{ entity }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedEntity" fill="clear" class="clear-filter-btn" @click="selectedEntity = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Related Feed')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedFeed"
-                @ionChange="selectedFeed = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All feeds") }}</ion-select-option>
-                <ion-select-option v-for="feed in dataFeeds" :key="feed" :value="feed">
-                  {{ feed }}
-                </ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Related Feed')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedFeed"
+                  @ionChange="selectedFeed = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All feeds") }}</ion-select-option>
+                  <ion-select-option v-for="feed in dataFeeds" :key="feed" :value="feed">
+                    {{ feed }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedFeed" fill="clear" class="clear-filter-btn" @click="selectedFeed = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>
@@ -132,7 +142,7 @@ import {
   IonToolbar,
   onIonViewWillEnter
 } from "@ionic/vue";
-import { addOutline, documentTextOutline, playOutline, timeOutline } from "ionicons/icons";
+import { addOutline, closeCircleOutline, documentTextOutline, playOutline, timeOutline } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import router from "../router"
 

--- a/src/views/DataDocumentExportHistory.vue
+++ b/src/views/DataDocumentExportHistory.vue
@@ -19,56 +19,83 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Document')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedDocumentId"
-                @ionChange="selectedDocumentId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All documents") }}</ion-select-option>
-                <ion-select-option v-for="document in documents" :key="document.dataDocumentId" :value="document.dataDocumentId">
-                  {{ document.documentName || document.dataDocumentId }}
-                </ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Document')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedDocumentId"
+                  @ionChange="selectedDocumentId = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All documents") }}</ion-select-option>
+                  <ion-select-option v-for="document in documents" :key="document.dataDocumentId" :value="document.dataDocumentId">
+                    {{ document.documentName || document.dataDocumentId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedDocumentId" fill="clear" class="clear-filter-btn" @click="selectedDocumentId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
               <!-- Status is filtered client-side using the same getExportStatus vocabulary the
                    badges render, so the options match what's shown on each row (and "Failed",
                    which is SmsgProduced + failCount > 0, can actually be isolated). -->
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatus"
-                @ionChange="selectedStatus = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All statuses") }}</ion-select-option>
-                <ion-select-option value="ready">{{ translate("Ready") }}</ion-select-option>
-                <ion-select-option value="processing">{{ translate("Processing") }}</ion-select-option>
-                <ion-select-option value="sending">{{ translate("Sending") }}</ion-select-option>
-                <ion-select-option value="failed">{{ translate("Failed") }}</ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Status')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedStatus"
+                  @ionChange="selectedStatus = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All statuses") }}</ion-select-option>
+                  <ion-select-option value="ready">{{ translate("Ready") }}</ion-select-option>
+                  <ion-select-option value="processing">{{ translate("Processing") }}</ion-select-option>
+                  <ion-select-option value="sending">{{ translate("Sending") }}</ion-select-option>
+                  <ion-select-option value="failed">{{ translate("Failed") }}</ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedStatus" fill="clear" class="clear-filter-btn" @click="selectedStatus = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-input
-                :value="startedBy"
-                @ionInput="startedBy = $event.detail.value || ''"
-                :label="translate('Started By')"
-                label-placement="stacked"
-              />
-              <ion-input
-                :value="fromDate"
-                @ionInput="fromDate = $event.detail.value || ''"
-                type="date"
-                :label="translate('From Date')"
-                label-placement="stacked"
-              />
-              <ion-input
-                :value="thruDate"
-                @ionInput="thruDate = $event.detail.value || ''"
-                type="date"
-                :label="translate('Thru Date')"
-                label-placement="stacked"
-              />
+              <div class="filter-item">
+                <ion-input
+                  :value="startedBy"
+                  @ionInput="startedBy = $event.detail.value || ''"
+                  :label="translate('Started By')"
+                  label-placement="stacked"
+                />
+                <ion-button v-if="startedBy" fill="clear" class="clear-filter-btn" @click="startedBy = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
+
+              <div class="filter-item">
+                <ion-input
+                  :value="fromDate"
+                  @ionInput="fromDate = $event.detail.value || ''"
+                  type="date"
+                  :label="translate('From Date')"
+                  label-placement="stacked"
+                />
+                <ion-button v-if="fromDate" fill="clear" class="clear-filter-btn" @click="fromDate = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
+
+              <div class="filter-item">
+                <ion-input
+                  :value="thruDate"
+                  @ionInput="thruDate = $event.detail.value || ''"
+                  type="date"
+                  :label="translate('Thru Date')"
+                  label-placement="stacked"
+                />
+                <ion-button v-if="thruDate" fill="clear" class="clear-filter-btn" @click="thruDate = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>
@@ -99,6 +126,7 @@ import {
   IonCardContent,
   IonContent,
   IonHeader,
+  IonIcon,
   IonInput,
   IonMenuButton,
   IonNote,
@@ -110,6 +138,7 @@ import {
   IonToolbar,
   onIonViewWillEnter
 } from "@ionic/vue";
+import { closeCircleOutline } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 
 import { translate } from "@common";

--- a/src/views/DataDocumentExportHistory.vue
+++ b/src/views/DataDocumentExportHistory.vue
@@ -63,6 +63,7 @@
                 <ion-input
                   :value="startedBy"
                   @ionInput="startedBy = $event.detail.value || ''"
+                  :debounce="300"
                   :label="translate('Started By')"
                   label-placement="stacked"
                 />

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -624,24 +624,6 @@ onIonViewWillEnter(async () => {
   gap: var(--spacer-lg);
 }
 
-.filter-item {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.filter-item ion-select {
-  flex: 1;
-}
-
-.clear-filter-btn {
-  --padding-start: 6px;
-  --padding-end: 6px;
-  flex-shrink: 0;
-  margin-inline-start: 4px;
-  height: 36px;
-  width: 36px;
-}
 
 .pagination {
   display: flex;

--- a/src/views/JobRunHistory.vue
+++ b/src/views/JobRunHistory.vue
@@ -92,6 +92,7 @@
                   label-placement="stacked"
                   fill="outline"
                   :placeholder="translate('Any user')"
+                  :debounce="300"
                   @ionInput="selectedUserId = $event.detail.value || ''"
                 />
                 <ion-button v-if="selectedUserId" fill="clear" class="clear-filter-btn" @click="selectedUserId = ''" :title="translate('Clear')">

--- a/src/views/JobRunHistory.vue
+++ b/src/views/JobRunHistory.vue
@@ -48,53 +48,73 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatus"
-                @ionChange="selectedStatus = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option value="RUNNING">{{ translate("Running") }}</ion-select-option>
-                <ion-select-option value="SUCCESSFUL">{{ translate("Successful") }}</ion-select-option>
-                <ion-select-option value="FAILED">{{ translate("Failed") }}</ion-select-option>
-                <ion-select-option value="TERMINATED">{{ translate("Terminated") }}</ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Status')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedStatus"
+                  @ionChange="selectedStatus = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option value="RUNNING">{{ translate("Running") }}</ion-select-option>
+                  <ion-select-option value="SUCCESSFUL">{{ translate("Successful") }}</ion-select-option>
+                  <ion-select-option value="FAILED">{{ translate("Failed") }}</ion-select-option>
+                  <ion-select-option value="TERMINATED">{{ translate("Terminated") }}</ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedStatus" fill="clear" class="clear-filter-btn" @click="selectedStatus = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Job')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedJobName"
-                @ionChange="selectedJobName = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option v-for="job in jobOptions" :key="job.jobName" :value="job.jobName">
-                  {{ job.jobName }}
-                </ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Job')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedJobName"
+                  @ionChange="selectedJobName = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option v-for="job in jobOptions" :key="job.jobName" :value="job.jobName">
+                    {{ job.jobName }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedJobName" fill="clear" class="clear-filter-btn" @click="selectedJobName = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-input
-                :value="selectedUserId"
-                :label="translate('User')"
-                label-placement="stacked"
-                fill="outline"
-                :placeholder="translate('Any user')"
-                @ionInput="selectedUserId = $event.detail.value || ''"
-              />
+              <div class="filter-item">
+                <ion-input
+                  :value="selectedUserId"
+                  :label="translate('User')"
+                  label-placement="stacked"
+                  fill="outline"
+                  :placeholder="translate('Any user')"
+                  @ionInput="selectedUserId = $event.detail.value || ''"
+                />
+                <ion-button v-if="selectedUserId" fill="clear" class="clear-filter-btn" @click="selectedUserId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Data logs')"
-                label-placement="stacked"
-                interface="popover"
-                :value="hasDataLogs"
-                @ionChange="hasDataLogs = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option value="Y">{{ translate("Has data logs") }}</ion-select-option>
-                <ion-select-option value="N">{{ translate("No data logs") }}</ion-select-option>
-              </ion-select>
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Data logs')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="hasDataLogs"
+                  @ionChange="hasDataLogs = $event.detail.value"
+                >
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option value="Y">{{ translate("Has data logs") }}</ion-select-option>
+                  <ion-select-option value="N">{{ translate("No data logs") }}</ion-select-option>
+                </ion-select>
+                <ion-button v-if="hasDataLogs" fill="clear" class="clear-filter-btn" @click="hasDataLogs = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -19,73 +19,93 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatusId"
-                @ionChange="selectedStatusId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="status in statuses"
-                  :key="status.statusId"
-                  :value="status.statusId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Status')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedStatusId"
+                  @ionChange="selectedStatusId = $event.detail.value"
                 >
-                  {{ status.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="status in statuses"
+                    :key="status.statusId"
+                    :value="status.statusId"
+                  >
+                    {{ status.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedStatusId" fill="clear" class="clear-filter-btn" @click="selectedStatusId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Parent Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedParentTypeId"
-                @ionChange="handleParentTypeChange($event)"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="parent in parentTypes"
-                  :key="parent.id"
-                  :value="parent.id"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Parent Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedParentTypeId"
+                  @ionChange="handleParentTypeChange($event)"
                 >
-                  {{ parent.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="parent in parentTypes"
+                    :key="parent.id"
+                    :value="parent.id"
+                  >
+                    {{ parent.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedParentTypeId" fill="clear" class="clear-filter-btn" @click="selectedParentTypeId = ''; selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Message Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedTypeId"
-                @ionChange="selectedTypeId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="type in filteredTypes"
-                  :key="type.systemMessageTypeId"
-                  :value="type.systemMessageTypeId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Message Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedTypeId"
+                  @ionChange="selectedTypeId = $event.detail.value"
                 >
-                  {{ type.description || type.systemMessageTypeId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="type in filteredTypes"
+                    :key="type.systemMessageTypeId"
+                    :value="type.systemMessageTypeId"
+                  >
+                    {{ type.description || type.systemMessageTypeId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedTypeId" fill="clear" class="clear-filter-btn" @click="selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Remote System')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedRemoteId"
-                @ionChange="selectedRemoteId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="remote in remotes"
-                  :key="remote.systemMessageRemoteId"
-                  :value="remote.systemMessageRemoteId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Remote System')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedRemoteId"
+                  @ionChange="selectedRemoteId = $event.detail.value"
                 >
-                  {{ remote.description || remote.systemMessageRemoteId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="remote in remotes"
+                    :key="remote.systemMessageRemoteId"
+                    :value="remote.systemMessageRemoteId"
+                  >
+                    {{ remote.description || remote.systemMessageRemoteId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedRemoteId" fill="clear" class="clear-filter-btn" @click="selectedRemoteId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>
@@ -115,6 +135,7 @@ import {
   IonCardContent,
   IonContent,
   IonHeader,
+  IonIcon,
   IonMenuButton,
   IonNote,
   IonPage,
@@ -125,6 +146,7 @@ import {
   IonToolbar,
   onIonViewWillEnter
 } from "@ionic/vue";
+import { closeCircleOutline } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import { translate } from "@common";
 import SystemMessageList from "@/components/SystemMessageList.vue";


### PR DESCRIPTION
## Related Issues

Closes #1026

## Description

This PR standardizes the filter experience across Job Manager by adding a consistent **clear (×)** action for active filters on list pages.

Previously, only the **File History** page displayed a clear action beside selected filters, allowing users to remove individual filters with a single click. Other pages required reopening the filter dropdown to clear selected values, resulting in an inconsistent user experience.

This change aligns the behavior across the following pages:

- Job Run History
- Message History
- Data Documents
- Data Document Export History

Additionally, clearing the **Parent Type** filter on the Message History page also clears the dependent **Message Type** filter to maintain a valid filter state.

## Changes Made

- Added clear (×) actions for active filters on:
  - `JobRunHistory.vue`
  - `SystemMessageMonitor.vue`
  - `DataDocumentCatalog.vue`
  - `DataDocumentExportHistory.vue`
- Reused the existing filter interaction pattern from **File History** for a consistent user experience.
- Moved shared `.filter-item` and `.clear-filter-btn` styles from `FileHistory.vue` to `variables.css` so they can be reused across pages.
- Ensured dependent filters are reset appropriately (for example, clearing **Parent Type** also clears **Message Type**).

## Verification

### Manual Testing

- Verified the clear (×) action appears only when a filter has an active value.
- Verified clicking the clear action removes only the selected filter.
- Verified the list refreshes after clearing a filter.
- Verified existing filtering behavior remains unchanged.
- Verified clearing **Parent Type** also resets the selected **Message Type**.
- Verified the UI is consistent across:
  - File History
  - Job Run History
  - Message History
  - Data Documents
  - Export History(Data Document Export History Page)

## Evidence

**Before:**
*<img width="1849" height="584" alt="Image" src="https://github.com/user-attachments/assets/5293e7f3-d805-43fd-9ad4-800ed38291dd" />*

**After:**
*<img width="1852" height="675" alt="image" src="https://github.com/user-attachments/assets/eb630d54-5506-44cc-aaa3-3846ef429c15" />*