### PR TITLE
fix: Add permission checks to System Message Type and Remote System detail/list pages (#1015)

### DIFF
--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -17,9 +17,9 @@
             <p>{{ form.description.value || translate("Configure remote system connectivity and inspect related messages.") }}</p>
           </div>
           <div class="header-actions">
-            <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" fill="outline" @click="saveRemote">{{ translate("Save") }}</ion-button>
+            <ion-button v-if="hasPermission('COMMON_ADMIN')" fill="outline" @click="saveRemote">{{ translate("Save") }}</ion-button>
             <ion-button
-              v-if="!isCreateMode && hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+              v-if="!isCreateMode && hasPermission('COMMON_ADMIN')"
               color="danger"
               fill="outline"
               @click="deleteRemote"
@@ -42,7 +42,7 @@
                   label-placement="stacked"
                   fill="outline"
                   auto-grow
-                  :readonly="!hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+                  :readonly="!hasPermission('COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -52,7 +52,7 @@
                   :label="translate(field.label)"
                   label-placement="stacked"
                   fill="outline"
-                  :readonly="(!isCreateMode && key === 'systemMessageRemoteId') || !hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+                  :readonly="(!isCreateMode && key === 'systemMessageRemoteId') || !hasPermission('COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -220,11 +220,6 @@ const loadRemote = async () => {
 };
 
 const saveRemote = async () => {
-  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
-    await showToast(translate("You do not have permission to save this config."));
-    return;
-  }
-
   if (!form.systemMessageRemoteId?.value.trim()) {
     await showToast(translate("Remote ID is required."));
     return;
@@ -252,11 +247,6 @@ const saveRemote = async () => {
 };
 
 const deleteRemote = async () => {
-  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
-    await showToast(translate("You do not have permission to delete this config."));
-    return;
-  }
-
   const result = await systemMessageStore.deleteSystemMessageRemote(props.id as string);
   if (result.error) {
     await showToast(translate("This remote system cannot be deleted while messages still reference it."));

--- a/src/views/SystemMessageRemoteDetail.vue
+++ b/src/views/SystemMessageRemoteDetail.vue
@@ -17,9 +17,9 @@
             <p>{{ form.description.value || translate("Configure remote system connectivity and inspect related messages.") }}</p>
           </div>
           <div class="header-actions">
-            <ion-button fill="outline" @click="saveRemote">{{ translate("Save") }}</ion-button>
+            <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" fill="outline" @click="saveRemote">{{ translate("Save") }}</ion-button>
             <ion-button
-              v-if="!isCreateMode"
+              v-if="!isCreateMode && hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
               color="danger"
               fill="outline"
               @click="deleteRemote"
@@ -42,6 +42,7 @@
                   label-placement="stacked"
                   fill="outline"
                   auto-grow
+                  :readonly="!hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -51,7 +52,7 @@
                   :label="translate(field.label)"
                   label-placement="stacked"
                   fill="outline"
-                  :readonly="!isCreateMode && key === 'systemMessageRemoteId'"
+                  :readonly="(!isCreateMode && key === 'systemMessageRemoteId') || !hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -146,6 +147,7 @@ import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { showToast } from "@/utils";
 import { useUtilStore } from "@/store/util";
+import { useUserStore } from "@/store/user";
 import { caretBackOutline, caretForwardOutline } from "ionicons/icons";
 
 // Type based declaration
@@ -156,6 +158,8 @@ const pageIndex = ref(0);
 
 const systemMessageStore = useSystemMessageStore();
 const utilStore = useUtilStore();
+const userStore = useUserStore();
+const hasPermission = computed(() => (permissionId: string) => userStore.hasPermission(permissionId));
 const queryString = ref("");
 const selectedStatusId = ref("");
 const form = reactive<Record<string, any>>({
@@ -216,6 +220,11 @@ const loadRemote = async () => {
 };
 
 const saveRemote = async () => {
+  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
+    await showToast(translate("You do not have permission to save this config."));
+    return;
+  }
+
   if (!form.systemMessageRemoteId?.value.trim()) {
     await showToast(translate("Remote ID is required."));
     return;
@@ -243,6 +252,11 @@ const saveRemote = async () => {
 };
 
 const deleteRemote = async () => {
+  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
+    await showToast(translate("You do not have permission to delete this config."));
+    return;
+  }
+
   const result = await systemMessageStore.deleteSystemMessageRemote(props.id as string);
   if (result.error) {
     await showToast(translate("This remote system cannot be deleted while messages still reference it."));

--- a/src/views/SystemMessageRemotes.vue
+++ b/src/views/SystemMessageRemotes.vue
@@ -5,7 +5,7 @@
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Remote Systems") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-button @click="router.push('/system-message-remotes/new')">
+          <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" @click="router.push('/system-message-remotes/new')">
             {{ translate("Create") }}
           </ion-button>
         </ion-buttons>
@@ -73,8 +73,11 @@ import router from "../router";
 import { translate } from "@common";
 
 import { useSystemMessageStore } from "@/store/systemMessage";
+import { useUserStore } from "@/store/user";
 
 const systemMessageStore = useSystemMessageStore();
+const userStore = useUserStore();
+const hasPermission = computed(() => (permissionId: string) => userStore.hasPermission(permissionId));
 const queryString = ref("");
 
 const remotes = computed(() => systemMessageStore.getSystemMessageRemotes);

--- a/src/views/SystemMessageRemotes.vue
+++ b/src/views/SystemMessageRemotes.vue
@@ -5,7 +5,7 @@
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Remote Systems") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" @click="router.push('/system-message-remotes/new')">
+          <ion-button v-if="hasPermission('COMMON_ADMIN')" @click="router.push('/system-message-remotes/new')">
             {{ translate("Create") }}
           </ion-button>
         </ion-buttons>

--- a/src/views/SystemMessageTypeDetail.vue
+++ b/src/views/SystemMessageTypeDetail.vue
@@ -17,9 +17,9 @@
             <p>{{ form.description.value || translate("Configure a system message type and inspect related messages.") }}</p>
           </div>
           <div class="header-actions">
-            <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" fill="outline" @click="saveType">{{ translate("Save") }}</ion-button>
+            <ion-button v-if="hasPermission('COMMON_ADMIN')" fill="outline" @click="saveType">{{ translate("Save") }}</ion-button>
             <ion-button
-              v-if="!isCreateMode && hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+              v-if="!isCreateMode && hasPermission('COMMON_ADMIN')"
               color="danger"
               fill="outline"
               @click="deleteType"
@@ -42,7 +42,7 @@
                   label-placement="stacked"
                   fill="outline"
                   auto-grow
-                  :readonly="!hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+                  :readonly="!hasPermission('COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -51,7 +51,7 @@
                   :label="translate(field.label)"
                   label-placement="stacked"
                   fill="outline"
-                  :readonly="(!isCreateMode && key === 'systemMessageTypeId') || !hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
+                  :readonly="(!isCreateMode && key === 'systemMessageTypeId') || !hasPermission('COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -208,11 +208,6 @@ const loadType = async() => {
 };
 
 const saveType = async () => {
-  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
-    await showToast(translate("You do not have permission to save this config."));
-    return;
-  }
-
   if (!form.systemMessageTypeId?.value.trim()) {
     await showToast(translate("Type ID is required."));
     return;
@@ -240,11 +235,6 @@ const saveType = async () => {
 };
 
 const deleteType = async () => {
-  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
-    await showToast(translate("You do not have permission to delete this config."));
-    return;
-  }
-
   const result = await store.deleteSystemMessageType(props.id);
   if (result.error) {
     await showToast(translate("This message type cannot be deleted while messages still reference it."));

--- a/src/views/SystemMessageTypeDetail.vue
+++ b/src/views/SystemMessageTypeDetail.vue
@@ -17,9 +17,9 @@
             <p>{{ form.description.value || translate("Configure a system message type and inspect related messages.") }}</p>
           </div>
           <div class="header-actions">
-            <ion-button fill="outline" @click="saveType">{{ translate("Save") }}</ion-button>
+            <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" fill="outline" @click="saveType">{{ translate("Save") }}</ion-button>
             <ion-button
-              v-if="!isCreateMode"
+              v-if="!isCreateMode && hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
               color="danger"
               fill="outline"
               @click="deleteType"
@@ -42,6 +42,7 @@
                   label-placement="stacked"
                   fill="outline"
                   auto-grow
+                  :readonly="!hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -50,7 +51,7 @@
                   :label="translate(field.label)"
                   label-placement="stacked"
                   fill="outline"
-                  :readonly="!isCreateMode && key === 'systemMessageTypeId'"
+                  :readonly="(!isCreateMode && key === 'systemMessageTypeId') || !hasPermission('SETUP_ADMIN OR COMMON_ADMIN')"
                   :value="field.value || ''"
                   @ionInput="updateField(key, $event.detail.value || '')"
                 />
@@ -143,6 +144,7 @@ import SystemMessageList from "@/components/SystemMessageList.vue";
 import { useSystemMessageStore } from "@/store/systemMessage";
 import { showToast } from "@/utils";
 import { useUtilStore } from "@/store/util";
+import { useUserStore } from "@/store/user";
 import { caretBackOutline, caretForwardOutline } from "ionicons/icons";
 
 const props = defineProps<{ id?: string }>();
@@ -152,6 +154,8 @@ const pageIndex = ref(0);
 
 const store = useSystemMessageStore();
 const utilStore = useUtilStore();
+const userStore = useUserStore();
+const hasPermission = computed(() => (permissionId: string) => userStore.hasPermission(permissionId));
 const queryString = ref("");
 const selectedStatusId = ref("");
 const form = reactive<Record<string, any>>({
@@ -204,6 +208,11 @@ const loadType = async() => {
 };
 
 const saveType = async () => {
+  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
+    await showToast(translate("You do not have permission to save this config."));
+    return;
+  }
+
   if (!form.systemMessageTypeId?.value.trim()) {
     await showToast(translate("Type ID is required."));
     return;
@@ -231,6 +240,11 @@ const saveType = async () => {
 };
 
 const deleteType = async () => {
+  if (!hasPermission.value('SETUP_ADMIN OR COMMON_ADMIN')) {
+    await showToast(translate("You do not have permission to delete this config."));
+    return;
+  }
+
   const result = await store.deleteSystemMessageType(props.id);
   if (result.error) {
     await showToast(translate("This message type cannot be deleted while messages still reference it."));

--- a/src/views/SystemMessageTypes.vue
+++ b/src/views/SystemMessageTypes.vue
@@ -5,7 +5,7 @@
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Message Types") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-button @click="router.push('/system-message-types/new')">
+          <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" @click="router.push('/system-message-types/new')">
             {{ translate("Create") }}
           </ion-button>
         </ion-buttons>
@@ -74,8 +74,11 @@ import router from "../router";
 import { translate } from "@common";
 
 import { useSystemMessageStore } from "@/store/systemMessage";
+import { useUserStore } from "@/store/user";
 
 const store = useSystemMessageStore();
+const userStore = useUserStore();
+const hasPermission = computed(() => (permissionId: string) => userStore.hasPermission(permissionId));
 const queryString = ref("");
 
 const types = computed(() => store.getSystemMessageTypes);

--- a/src/views/SystemMessageTypes.vue
+++ b/src/views/SystemMessageTypes.vue
@@ -5,7 +5,7 @@
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Message Types") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-button v-if="hasPermission('SETUP_ADMIN OR COMMON_ADMIN')" @click="router.push('/system-message-types/new')">
+          <ion-button v-if="hasPermission('COMMON_ADMIN')" @click="router.push('/system-message-types/new')">
             {{ translate("Create") }}
           </ion-button>
         </ion-buttons>


### PR DESCRIPTION
## Description
Restricts create, save, and delete actions for System Message Types and Remote Systems configurations to users with `SETUP_ADMIN` or `COMMON_ADMIN` permissions (i.e., members of `COMMERCE_SUPER` or `super` security groups). Other users will see a read-only view.

## Related Issue
Fixes #1015

## Changes
- Hid the **Save** and **Delete** buttons on the detail pages for unauthorized users.
- Set configuration form input/textarea fields to `readonly` for unauthorized users.
- Added method-level checks in components to prevent save/delete actions and show warning toasts if permissions are missing.