### PR TITLE
Fix: show loading state on Message History and File History pages (#1039)

### DIFF
--- a/src/components/SystemMessageList.vue
+++ b/src/components/SystemMessageList.vue
@@ -1,5 +1,9 @@
 <template>
-  <ion-list v-if="messages.length">
+  <div v-if="isLoading" class="loading-state">
+    <ion-spinner name="crescent" />
+    <p>{{ translate("Loading") }}</p>
+  </div>
+  <ion-list v-else-if="messages.length">
     <ion-card v-for="message in messages" :key="message.systemMessageId" class="list-item"
         @click="router.push(`/system-messages/${message.systemMessageId}`)">
       <ion-item lines="none">
@@ -30,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonBadge, IonCard, IonIcon, IonItem, IonLabel, IonList } from "@ionic/vue";
+import { IonBadge, IonCard, IonIcon, IonItem, IonLabel, IonList, IonSpinner } from "@ionic/vue";
 import { downloadOutline, sendOutline } from "ionicons/icons";
 import { translate } from "@common";
 import { commonUtil } from "@common/utils/commonUtil"
@@ -44,10 +48,12 @@ withDefaults(defineProps<{
   emptyMessage?: string;
   showRemote?: boolean;
   showType?: boolean;
+  isLoading?: boolean;
 }>(), {
   emptyMessage: "No messages found.",
   showRemote: true,
-  showType: true
+  showType: true,
+  isLoading: false
 });
 
 const systemMessageStore = useSystemMessageStore();
@@ -62,6 +68,7 @@ const getTypeName = (typeId: string) => {
 </script>
 
 <style scoped>
+.loading-state,
 .empty-state {
   padding: 24px;
   text-align: center;

--- a/src/store/mdmConfig.ts
+++ b/src/store/mdmConfig.ts
@@ -9,6 +9,7 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
     executionModes: [] as Array<any>,
     logs: [] as Array<any>,
     logsCount: 0,
+    isFetchingLogs: false,
     filters: {} as Record<string, any>,
     globalStats: { total: 0, successful: 0, failed: 0, avgProcessingTime: 0 },
     fetchStatus: {
@@ -107,6 +108,7 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
       }
     },
     async fetchDataManagerLogs(params = { pageSize: 10, pageIndex: 0 }) {
+      this.isFetchingLogs = true;
       try {
         const payload = {
           ...params
@@ -154,6 +156,8 @@ export const useMdmConfigStore = defineStore("mdmConfig", {
         }
       } catch (err) {
         logger.error("Failed to fetch logs", err)
+      } finally {
+        this.isFetchingLogs = false;
       }
     },
     async fetchDataManagerLogById(logId: string) {

--- a/src/store/systemMessage.ts
+++ b/src/store/systemMessage.ts
@@ -32,6 +32,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     linkedMessages: [] as any[],
     systemMessageTotal: 0,
     loading: false,
+    isFetchingMessages: false,
     enums: [] as any[],
     currentSystemMessageStatusHistory: []
   }),
@@ -113,6 +114,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
     },
     async fetchSystemMessages(payload: Record<string, any> = {}) {
       this.loading = true;
+      this.isFetchingMessages = true;
 
       try {
         const response = await api({
@@ -139,6 +141,7 @@ export const useSystemMessageStore = defineStore("systemMessage", {
         this.systemMessageTotal = 0;
       } finally {
         this.loading = false;
+        this.isFetchingMessages = false;
       }
     },
     async fetchSystemMessageById(systemMessageId: string, skipSetCurrent = false) {

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -130,7 +130,7 @@
         </ion-card>
 
         <div class="pagination">
-          <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
+          <ion-button fill="outline" :disabled="pageIndex === 0 || isFetchingLogs" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
           <div class="page-input">
@@ -146,12 +146,17 @@
             />
             <span>/ {{ pageCount }}</span>
           </div>
-          <ion-button fill="outline" :disabled="pageIndex + 1 >= pageCount" @click="goToNextPage">
+          <ion-button fill="outline" :disabled="pageIndex + 1 >= pageCount || isFetchingLogs" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
         </div>
 
-        <ion-list>
+        <div v-if="isFetchingLogs" class="loading-state">
+          <ion-spinner name="crescent" />
+          <p>{{ translate("Loading") }}</p>
+        </div>
+
+        <ion-list v-else-if="logs.length">
           <ion-card
             v-for="log in logs"
             :key="log.logId"
@@ -195,8 +200,8 @@
               </ion-button>
             </ion-label>
           </ion-card>
-          <p class="empty-state" v-if="!logs.length">{{ translate("No logs found") }}</p>
         </ion-list>
+        <p class="empty-state" v-else>{{ translate("No logs found") }}</p>
       </main>
 
       <ion-modal trigger="config-filter-trigger" @willPresent="handleConfigModalWillPresent" @didDismiss="clearConfigModal">
@@ -262,6 +267,7 @@ import {
   IonSearchbar,
   IonSelect,
   IonSelectOption,
+  IonSpinner,
   IonTitle,
   IonToolbar,
   IonMenuButton,
@@ -300,6 +306,7 @@ const configQuery = ref("");
 const pageIndex = ref(0);
 
 const rawLogs = computed(() => mdmStore.getLogs);
+const isFetchingLogs = computed(() => mdmStore.isFetchingLogs);
 const configs = computed(() => mdmStore.getConfigs);
 const statusItems = computed(() => utilStore.getStatusItemsByType("DataManagerLog"));
 
@@ -582,6 +589,12 @@ onIonViewWillEnter(async () => {
 </script>
 
 <style scoped>
+.loading-state,
+.empty-state {
+  text-align: center;
+  padding: var(--spacer-lg);
+  color: var(--ion-color-medium);
+}
 
 
 .limit-chip {

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -142,6 +142,7 @@
               :value="pageIndex + 1"
               @keyup="validatePageInput($event)"
               @change="goToPage($event)"
+              :disabled="isFetchingLogs"
               class="page-number-input"
             />
             <span>/ {{ pageCount }}</span>

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -91,17 +91,17 @@
         </ion-card>
 
         <div class="pagination">
-          <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
+          <ion-button fill="outline" :disabled="pageIndex === 0 || isLoading" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
           <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
-          <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
+          <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1 || isLoading" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
         </div>
         <SystemMessageList
           :messages="messages"
-          :is-loading="store.isLoading"
+          :is-loading="isLoading"
           :empty-message="translate('No system messages found for the selected filters.')"
         />
       </main>
@@ -145,6 +145,7 @@ const selectedTypeId = ref("");
 const selectedParentTypeId = ref("");
 const selectedRemoteId = ref("");
 const pageIndex = ref(0);
+const isInitialLoading = ref(true);
 
 const messages = computed(() => store.getSystemMessages);
 const total = computed(() => store.getSystemMessageTotal);
@@ -153,6 +154,7 @@ const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
 const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const isLoading = computed(() => isInitialLoading.value || store.isFetchingMessages);
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -217,17 +219,22 @@ watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, sele
 watch(pageIndex, loadMessages);
 
 onIonViewWillEnter(async () => {
+  isInitialLoading.value = true;
   if (route.query?.statusId) {
     selectedStatusId.value = route.query.statusId as string;
   } else {
     selectedStatusId.value = "";
   }
-  await Promise.all([
-    store.fetchSystemMessageTypes(),
-    store.fetchSystemMessageRemotes(),
-    store.fetchSystemMessageStatusMetadata()
-  ]);
-  await loadMessages();
+  try {
+    await Promise.all([
+      store.fetchSystemMessageTypes(),
+      store.fetchSystemMessageRemotes(),
+      store.fetchSystemMessageStatusMetadata()
+    ]);
+    await loadMessages();
+  } finally {
+    isInitialLoading.value = false;
+  }
 });
 </script>
 

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -101,6 +101,7 @@
         </div>
         <SystemMessageList
           :messages="messages"
+          :is-loading="store.isLoading"
           :empty-message="translate('No system messages found for the selected filters.')"
         />
       </main>


### PR DESCRIPTION
### Related Issues

Closes #1039

---

### Description

This PR improves the user experience on the **Message History** and **File History** pages by displaying a loading state while data is being fetched.

Previously, these pages could display their empty-state placeholders before requests completed, making it appear as though no data existed or the application was unresponsive.

---

### Changes Made

#### `src/store/mdmConfig.ts`

- Added loading state tracking for log fetching.
- Updated asynchronous actions to correctly manage loading state throughout the request lifecycle.

#### `src/components/SystemMessageList.vue`

- Added support for rendering a loading state while message data is being fetched.

#### `src/views/SystemMessageMonitor.vue`

- Connected the view to the store loading state.

#### `src/views/FileHistory.vue`

- Displayed a loading indicator while fetching file history.
- Updated the view to render the empty state only after loading completes.

---

### Verification

- Verified loading indicators appear during initial page load.
- Verified loading indicators appear while changing filters.
- Verified empty states are displayed only after requests complete with no results.
- Verified data is rendered correctly after loading finishes.
- Verified existing filtering and pagination behavior remains unchanged.

---

### Impact

- Improves user feedback during asynchronous operations.
- Prevents empty-state flickering while requests are in progress.
- Provides a more consistent loading experience across Job Manager pages.