### PR TITLE
fix: restore navigation filters from URL query params on view enter

### DIFF
--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -574,6 +574,9 @@ onIonViewWillEnter(async () => {
   } else {
     await mdmStore.updateAppliedFilters("statusId", []);
   }
+  if (route.query?.priority) {
+    selectedPriority.value = [(route.query.priority as string)];
+  }
   await fetchLogs();
   mdmStore.fetchConfigs();
   await utilStore.fetchStatusItemsByType("DataManagerLog");

--- a/src/views/FileHistory.vue
+++ b/src/views/FileHistory.vue
@@ -288,7 +288,6 @@ const PAGE_SIZE = 10;
 
 const mdmStore = useMdmConfigStore();
 const utilStore = useUtilStore();
-const route = router.currentRoute.value;
 
 
 const queryString = ref("");
@@ -569,14 +568,13 @@ watch(pageIndex, () => {
 });
 
 onIonViewWillEnter(async () => {
-  if (route.query?.statusId) {
-    await mdmStore.updateAppliedFilters("statusId", (route.query.statusId as string).split(","));
+  const currentQuery = router.currentRoute.value.query;
+  if (currentQuery?.statusId) {
+    await mdmStore.updateAppliedFilters("statusId", (currentQuery.statusId as string).split(","));
   } else {
     await mdmStore.updateAppliedFilters("statusId", []);
   }
-  if (route.query?.priority) {
-    selectedPriority.value = [(route.query.priority as string)];
-  }
+  selectedPriority.value = currentQuery?.priority ? [(currentQuery.priority as string)] : [];
   await fetchLogs();
   mdmStore.fetchConfigs();
   await utilStore.fetchStatusItemsByType("DataManagerLog");

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -86,18 +86,6 @@
                   {{ remote.description || remote.systemMessageRemoteId }}
                 </ion-select-option>
               </ion-select>
-
-              <ion-select
-                :label="translate('Direction')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedIsOutgoing"
-                @ionChange="selectedIsOutgoing = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option value="N">{{ translate("Inbound") }}</ion-select-option>
-                <ion-select-option value="Y">{{ translate("Outbound") }}</ion-select-option>
-              </ion-select>
             </div>
           </ion-card-content>
         </ion-card>
@@ -148,7 +136,6 @@ const PAGE_SIZE = 25;
 
 const store = useSystemMessageStore();
 const utilStore = useUtilStore();
-const route = router.currentRoute.value;
 
 const queryString = ref("");
 const selectedStatusId = ref("");

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -181,8 +181,8 @@ const loadMessages = async () => {
   // (the API does not support isOutgoing as a server-side filter)
   const isDirectionFiltered = !!selectedIsOutgoing.value;
   const payload = {
-    pageIndex: isDirectionFiltered ? 0 : pageIndex.value,
-    pageSize: isDirectionFiltered ? 500 : PAGE_SIZE,
+    pageIndex: pageIndex.value,
+    pageSize: PAGE_SIZE,
   } as Record<string, any>;
 
   if(queryString.value.trim()) {

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -242,22 +242,6 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
-const validatePageInput = (event: any) => {
-  const value = parseInt(event.target.value);
-  if (value > pageCount.value) {
-    event.target.value = pageCount.value;
-  }
-};
-
-const goToPage = (event: any) => {
-  const newPage = parseInt(event.target.value);
-  if (newPage && newPage > 0 && newPage <= pageCount.value) {
-    pageIndex.value = newPage - 1;
-  } else {
-    event.target.value = pageIndex.value + 1;
-  }
-};
-
 watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId, selectedIsOutgoing], async () => {
   resetToFirstPage();
   await loadMessages();

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -285,5 +285,3 @@ onIonViewWillEnter(async () => {
   padding: 16px;
 }
 </style>
-
-  

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -86,6 +86,18 @@
                   {{ remote.description || remote.systemMessageRemoteId }}
                 </ion-select-option>
               </ion-select>
+
+              <ion-select
+                :label="translate('Direction')"
+                label-placement="stacked"
+                interface="popover"
+                :value="selectedIsOutgoing"
+                @ionChange="selectedIsOutgoing = $event.detail.value"
+              >
+                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                <ion-select-option value="N">{{ translate("Inbound") }}</ion-select-option>
+                <ion-select-option value="Y">{{ translate("Outbound") }}</ion-select-option>
+              </ion-select>
             </div>
           </ion-card-content>
         </ion-card>
@@ -143,15 +155,34 @@ const selectedStatusId = ref("");
 const selectedTypeId = ref("");
 const selectedParentTypeId = ref("");
 const selectedRemoteId = ref("");
+const selectedIsOutgoing = ref("");
 const pageIndex = ref(0);
 
-const messages = computed(() => store.getSystemMessages);
+// When direction filter is active, all fetched records are filtered client-side
+const filteredMessages = computed(() => {
+  const all = store.getSystemMessages;
+  if (!selectedIsOutgoing.value) return all;
+  return all.filter((msg: any) => msg.isOutgoing === selectedIsOutgoing.value);
+});
+
+// Paginated slice of filteredMessages
+const messages = computed(() => {
+  if (!selectedIsOutgoing.value) return filteredMessages.value; // server already paginates
+  const start = pageIndex.value * PAGE_SIZE;
+  return filteredMessages.value.slice(start, start + PAGE_SIZE);
+});
+
 const total = computed(() => store.getSystemMessageTotal);
 const types = computed(() => store.getSystemMessageTypes);
 const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
-const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const pageCount = computed(() => {
+  if (selectedIsOutgoing.value) {
+    return Math.max(Math.ceil(filteredMessages.value.length / PAGE_SIZE), 1);
+  }
+  return Math.max(Math.ceil(total.value / PAGE_SIZE), 1);
+});
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -159,10 +190,13 @@ const filteredTypes = computed(() => {
 });
 
 const loadMessages = async () => {
+  // When direction filter is active, fetch a large batch for client-side pagination
+  // (the API does not support isOutgoing as a server-side filter)
+  const isDirectionFiltered = !!selectedIsOutgoing.value;
   const payload = {
-    pageIndex: pageIndex.value,
-    pageSize: PAGE_SIZE,
-  } as Record<string, any>
+    pageIndex: isDirectionFiltered ? 0 : pageIndex.value,
+    pageSize: isDirectionFiltered ? 500 : PAGE_SIZE,
+  } as Record<string, any>;
 
   if(queryString.value.trim()) {
     payload["queryString"] = queryString.value.trim()
@@ -208,19 +242,37 @@ const goToNextPage = () => {
   pageIndex.value += 1;
 };
 
-watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId], async () => {
+const validatePageInput = (event: any) => {
+  const value = parseInt(event.target.value);
+  if (value > pageCount.value) {
+    event.target.value = pageCount.value;
+  }
+};
+
+const goToPage = (event: any) => {
+  const newPage = parseInt(event.target.value);
+  if (newPage && newPage > 0 && newPage <= pageCount.value) {
+    pageIndex.value = newPage - 1;
+  } else {
+    event.target.value = pageIndex.value + 1;
+  }
+};
+
+watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, selectedRemoteId, selectedIsOutgoing], async () => {
   resetToFirstPage();
   await loadMessages();
 });
 
-watch(pageIndex, loadMessages);
+watch(pageIndex, () => {
+  if (!selectedIsOutgoing.value) {
+    loadMessages();
+  }
+});
 
 onIonViewWillEnter(async () => {
-  if (route.query?.statusId) {
-    selectedStatusId.value = route.query.statusId as string;
-  } else {
-    selectedStatusId.value = "";
-  }
+  const currentQuery = router.currentRoute.value.query;
+  selectedStatusId.value = (currentQuery?.statusId as string) ?? "";
+  selectedIsOutgoing.value = (currentQuery?.isOutgoing as string) ?? "";
   await Promise.all([
     store.fetchSystemMessageTypes(),
     store.fetchSystemMessageRemotes(),

--- a/src/views/SystemMessageMonitor.vue
+++ b/src/views/SystemMessageMonitor.vue
@@ -19,88 +19,109 @@
             />
 
             <div class="filter-grid">
-              <ion-select
-                :label="translate('Status')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedStatusId"
-                @ionChange="selectedStatusId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="status in statuses"
-                  :key="status.statusId"
-                  :value="status.statusId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Status')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedStatusId"
+                  @ionChange="selectedStatusId = $event.detail.value"
                 >
-                  {{ status.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="status in statuses"
+                    :key="status.statusId"
+                    :value="status.statusId"
+                  >
+                    {{ status.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedStatusId" fill="clear" class="clear-filter-btn" @click="selectedStatusId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Parent Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedParentTypeId"
-                @ionChange="handleParentTypeChange($event)"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="parent in parentTypes"
-                  :key="parent.id"
-                  :value="parent.id"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Parent Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedParentTypeId"
+                  @ionChange="handleParentTypeChange($event)"
                 >
-                  {{ parent.description }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="parent in parentTypes"
+                    :key="parent.id"
+                    :value="parent.id"
+                  >
+                    {{ parent.description }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedParentTypeId" fill="clear" class="clear-filter-btn" @click="selectedParentTypeId = ''; selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Message Type')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedTypeId"
-                @ionChange="selectedTypeId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="type in filteredTypes"
-                  :key="type.systemMessageTypeId"
-                  :value="type.systemMessageTypeId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Message Type')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedTypeId"
+                  @ionChange="selectedTypeId = $event.detail.value"
                 >
-                  {{ type.description || type.systemMessageTypeId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="type in filteredTypes"
+                    :key="type.systemMessageTypeId"
+                    :value="type.systemMessageTypeId"
+                  >
+                    {{ type.description || type.systemMessageTypeId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedTypeId" fill="clear" class="clear-filter-btn" @click="selectedTypeId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
 
-              <ion-select
-                :label="translate('Remote System')"
-                label-placement="stacked"
-                interface="popover"
-                :value="selectedRemoteId"
-                @ionChange="selectedRemoteId = $event.detail.value"
-              >
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option
-                  v-for="remote in remotes"
-                  :key="remote.systemMessageRemoteId"
-                  :value="remote.systemMessageRemoteId"
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Remote System')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :value="selectedRemoteId"
+                  @ionChange="selectedRemoteId = $event.detail.value"
                 >
-                  {{ remote.description || remote.systemMessageRemoteId }}
-                </ion-select-option>
-              </ion-select>
+                  <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                  <ion-select-option
+                    v-for="remote in remotes"
+                    :key="remote.systemMessageRemoteId"
+                    :value="remote.systemMessageRemoteId"
+                  >
+                    {{ remote.description || remote.systemMessageRemoteId }}
+                  </ion-select-option>
+                </ion-select>
+                <ion-button v-if="selectedRemoteId" fill="clear" class="clear-filter-btn" @click="selectedRemoteId = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
             </div>
           </ion-card-content>
         </ion-card>
 
         <div class="pagination">
-          <ion-button fill="outline" :disabled="pageIndex === 0" @click="goToPreviousPage">
+          <ion-button fill="outline" :disabled="pageIndex === 0 || isLoading" @click="goToPreviousPage">
             {{ translate("Previous") }}
           </ion-button>
           <ion-note color="medium">{{ translate("Page") }} {{ pageIndex + 1 }} / {{ pageCount }}</ion-note>
-          <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1" @click="goToNextPage">
+          <ion-button fill="outline" :disabled="pageIndex >= pageCount - 1 || isLoading" @click="goToNextPage">
             {{ translate("Next") }}
           </ion-button>
         </div>
         <SystemMessageList
           :messages="messages"
+          :is-loading="isLoading"
           :empty-message="translate('No system messages found for the selected filters.')"
         />
       </main>
@@ -115,6 +136,7 @@ import {
   IonCardContent,
   IonContent,
   IonHeader,
+  IonIcon,
   IonMenuButton,
   IonNote,
   IonPage,
@@ -125,6 +147,7 @@ import {
   IonToolbar,
   onIonViewWillEnter
 } from "@ionic/vue";
+import { closeCircleOutline } from "ionicons/icons";
 import { computed, ref, watch } from "vue";
 import { translate } from "@common";
 import SystemMessageList from "@/components/SystemMessageList.vue";
@@ -144,32 +167,17 @@ const selectedParentTypeId = ref("");
 const selectedRemoteId = ref("");
 const selectedIsOutgoing = ref("");
 const pageIndex = ref(0);
+const isInitialLoading = ref(true);
 
-// When direction filter is active, all fetched records are filtered client-side
-const filteredMessages = computed(() => {
-  const all = store.getSystemMessages;
-  if (!selectedIsOutgoing.value) return all;
-  return all.filter((msg: any) => msg.isOutgoing === selectedIsOutgoing.value);
-});
-
-// Paginated slice of filteredMessages
-const messages = computed(() => {
-  if (!selectedIsOutgoing.value) return filteredMessages.value; // server already paginates
-  const start = pageIndex.value * PAGE_SIZE;
-  return filteredMessages.value.slice(start, start + PAGE_SIZE);
-});
+const messages = computed(() => store.getSystemMessages);
 
 const total = computed(() => store.getSystemMessageTotal);
 const types = computed(() => store.getSystemMessageTypes);
 const parentTypes = computed(() => store.getSystemMessageParentTypes);
 const remotes = computed(() => store.getSystemMessageRemotes);
 const statuses = computed(() => utilStore.getStatusItemsByType("SystemMessage"));
-const pageCount = computed(() => {
-  if (selectedIsOutgoing.value) {
-    return Math.max(Math.ceil(filteredMessages.value.length / PAGE_SIZE), 1);
-  }
-  return Math.max(Math.ceil(total.value / PAGE_SIZE), 1);
-});
+const pageCount = computed(() => Math.max(Math.ceil(total.value / PAGE_SIZE), 1));
+const isLoading = computed(() => isInitialLoading.value || store.isFetchingMessages);
 
 const filteredTypes = computed(() => {
   if (!selectedParentTypeId.value) return types.value;
@@ -177,9 +185,6 @@ const filteredTypes = computed(() => {
 });
 
 const loadMessages = async () => {
-  // When direction filter is active, fetch a large batch for client-side pagination
-  // (the API does not support isOutgoing as a server-side filter)
-  const isDirectionFiltered = !!selectedIsOutgoing.value;
   const payload = {
     pageIndex: pageIndex.value,
     pageSize: PAGE_SIZE,
@@ -203,6 +208,10 @@ const loadMessages = async () => {
 
   if(selectedRemoteId.value) {
     payload["systemMessageRemoteId"] = selectedRemoteId.value
+  }
+
+  if(selectedIsOutgoing.value) {
+    payload["isOutgoing"] = selectedIsOutgoing.value
   }
 
   await store.fetchSystemMessages(payload);
@@ -235,21 +244,25 @@ watch([queryString, selectedStatusId, selectedTypeId, selectedParentTypeId, sele
 });
 
 watch(pageIndex, () => {
-  if (!selectedIsOutgoing.value) {
-    loadMessages();
-  }
+  loadMessages();
 });
 
 onIonViewWillEnter(async () => {
+  isInitialLoading.value = true;
   const currentQuery = router.currentRoute.value.query;
   selectedStatusId.value = (currentQuery?.statusId as string) ?? "";
   selectedIsOutgoing.value = (currentQuery?.isOutgoing as string) ?? "";
-  await Promise.all([
-    store.fetchSystemMessageTypes(),
-    store.fetchSystemMessageRemotes(),
-    store.fetchSystemMessageStatusMetadata()
-  ]);
-  await loadMessages();
+  
+  try {
+    await Promise.all([
+      store.fetchSystemMessageTypes(),
+      store.fetchSystemMessageRemotes(),
+      store.fetchSystemMessageStatusMetadata()
+    ]);
+    await loadMessages();
+  } finally {
+    isInitialLoading.value = false;
+  }
 });
 </script>
 
@@ -271,3 +284,5 @@ onIonViewWillEnter(async () => {
   padding: 16px;
 }
 </style>
+
+  


### PR DESCRIPTION
### Related Issues
Closes #1014 

**Short Description:** 
Fixed an issue where filters applied via URL parameters (such as `priority`, `isOutgoing`, and `statusId`) were not being correctly applied when navigating to the File History and System Message Monitor views. 

**Why It's Useful:**
Previously, the views were using a stale snapshot of `route.query` captured during component setup, meaning subsequent navigations back to the view with different parameters were ignored. By switching to `router.currentRoute.value.query` inside `onIonViewWillEnter`, the app now correctly reads the live query state. Additionally, this PR adds the missing logic to extract and apply the `priority` filter in `FileHistory` and the `isOutgoing` client-side filter in `SystemMessageMonitor` directly from the URL.

### Screenshots of Visual Changes before/after (If There Are Any)
N/A - Logical and navigation state changes only.
