### PR TITLE
Fix: Client-side pagination and filter reset for job run history (#1018)

### DIFF
--- a/src/store/jobs.spec.ts
+++ b/src/store/jobs.spec.ts
@@ -203,4 +203,35 @@ describe("job store detail", () => {
     ]);
     expect(store.getJobRunHistoryStats.failed).toBe(1);
   });
+
+  it("paginates client-side without making additional network calls when isRefetch is false", async () => {
+    const store = useJobStore();
+    store.jobs = [{ jobName: "syncOrders", serviceName: "co.hotwax.SyncOrders" }];
+
+    apiMock.mockResolvedValue({
+      data: Array.from({ length: 30 }, (_, i) => ({
+        jobRunId: String(i + 1),
+        startTime: 1710000000000 + i * 1000,
+        endTime: 1710000005000 + i * 1000,
+        hasError: "N",
+        userId: "system"
+      }))
+    });
+
+    // Initial fetch (isRefetch: true)
+    await store.fetchJobRunHistory({ pageSize: 10, pageIndex: 0, isRefetch: true });
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(store.getJobRunHistory.length).toBe(10);
+    expect(store.getJobRunHistoryTotal).toBe(30);
+
+    apiMock.mockClear();
+
+    // Paginate to pageIndex: 1 with isRefetch: false
+    await store.fetchJobRunHistory({ pageSize: 10, pageIndex: 1, isRefetch: false });
+
+    // Verify zero API calls were made and page 2 items were returned
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(store.getJobRunHistory.length).toBe(10);
+    expect(store.getJobRunHistory[0].jobRunId).toBe("20");
+  });
 });

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -65,6 +65,7 @@ export const useJobStore = defineStore("job", {
     categoryRollups: [] as Array<any>,
     products: {} as any,
     jobRunHistory: [] as Array<any>,
+    allJobRunHistory: [] as Array<any>,
     jobRunHistoryTotal: 0,
     jobRunHistoryStats: {
       total: 0,
@@ -318,12 +319,20 @@ export const useJobStore = defineStore("job", {
       return Array.isArray(jobRuns) ? jobRuns : []
     },
     async fetchJobRunHistory(payload: Record<string, any> = {}) {
+      const isRefetch = payload.isRefetch ?? true;
+      const pageSize = Number(payload.pageSize ?? 25);
+      const pageIndex = Number(payload.pageIndex ?? 0);
+
+      if (!isRefetch && this.allJobRunHistory.length > 0) {
+        const start = pageIndex * pageSize;
+        this.jobRunHistory = this.allJobRunHistory.slice(start, start + pageSize);
+        return;
+      }
+
       this.loading = true;
       try {
         if (!this.jobs.length) await this.fetchJobs();
 
-        const pageSize = Number(payload.pageSize ?? 25);
-        const pageIndex = Number(payload.pageIndex ?? 0);
         const runsPerJob = Number(payload.runsPerJob ?? 25);
         const queryString = (payload.queryString || "").trim().toLowerCase();
         const normalizedQueryString = queryString.replace(/^#/, "");
@@ -416,6 +425,7 @@ export const useJobStore = defineStore("job", {
 
         runs = runs.sort((first: any, second: any) => getRunTime(second) - getRunTime(first));
 
+        this.allJobRunHistory = runs;
         this.jobRunHistoryTotal = runs.length;
         this.jobRunHistoryStats = getRunHistoryStats(runs);
 
@@ -423,6 +433,7 @@ export const useJobStore = defineStore("job", {
         this.jobRunHistory = runs.slice(start, start + pageSize);
       } catch(err) {
         logger.error("Failed to fetch job run history", err);
+        this.allJobRunHistory = [];
         this.jobRunHistory = [];
         this.jobRunHistoryTotal = 0;
         this.jobRunHistoryStats = {

--- a/src/views/JobRunHistory.vue
+++ b/src/views/JobRunHistory.vue
@@ -383,11 +383,14 @@ const handleQueryInput = (event: CustomEvent) => {
   queryString.value = (event as any).detail.value || "";
 };
 
-const loadRuns = async () => {
+let isFilterResetting = false;
+
+const loadRuns = async (isRefetch = true) => {
   const payload = {
     pageIndex: pageIndex.value,
     pageSize: PAGE_SIZE,
-    runsPerJob: RUNS_PER_JOB
+    runsPerJob: RUNS_PER_JOB,
+    isRefetch
   } as Record<string, any>;
 
   if (queryString.value.trim()) payload.queryString = queryString.value.trim();
@@ -421,14 +424,18 @@ const goToLog = (logId: string | number) => {
 
 watch([queryString, selectedStatus, selectedJobName, selectedUserId, hasDataLogs], async () => {
   if (pageIndex.value !== 0) {
+    isFilterResetting = true;
     pageIndex.value = 0;
-  } else {
-    await loadRuns();
   }
-})
+  await loadRuns(true);
+});
 
 watch(pageIndex, async () => {
-  await loadRuns();
+  if (isFilterResetting) {
+    isFilterResetting = false;
+    return;
+  }
+  await loadRuns(false);
 });
 
 onIonViewWillEnter(async () => {
@@ -438,7 +445,7 @@ onIonViewWillEnter(async () => {
   if (route.query.userId) selectedUserId.value = route.query.userId as string;
 
   await jobStore.fetchJobs();
-  await loadRuns();
+  await loadRuns(true);
 });
 </script>
 


### PR DESCRIPTION
### Related Issue
Closes #1018

### Problem
1. **Redundant Network Calls on Page Navigation**: On the Service Job Run History page (`/job-run-history`), clicking "Next" or "Previous" triggered a full re-fetch from the server across all configured jobs. Each request sent `pageIndex=0` to Moqui backend, causing unnecessary network overhead and slow page transitions.
2. **Filter Reset Swallowed Refetch**: Changing a search query or filter while on Page 2+ (`pageIndex > 0`) reset `pageIndex` to `0`, but did not execute a fresh fetch from the server, leaving stale filtered results on screen.

### Proposed Changes
- **Client-Side Pagination Caching (`src/store/jobs.ts`)**:
  - Added `allJobRunHistory` state to cache fetched run records.
  - Introduced `isRefetch` payload flag in `fetchJobRunHistory()`. When `isRefetch: false`, it slices `allJobRunHistory` client-side directly based on `pageIndex * pageSize`, executing **zero network requests**.
- **Filter Reset Orchestration (`src/views/JobRunHistory.vue`)**:
  - Introduced `isFilterResetting` boolean flag.
  - Updated `watch([queryString, selectedStatus, selectedJobName, selectedUserId, hasDataLogs])` to always trigger `loadRuns(true)` on filter changes and set `isFilterResetting = true` if `pageIndex !== 0`.
  - Updated `watch(pageIndex)` to call `loadRuns(false)` (instant client slice) during page navigation and skip when `isFilterResetting` is active.
- **Unit Test Coverage (`src/store/jobs.spec.ts`)**:
  - Added unit test asserting that `isRefetch: false` makes 0 API calls and returns the sliced items for page 2.

### How Has This Been Tested?
- [x] Ran Vitest unit tests (`npx vitest run src/store/jobs.spec.ts`): All 6 tests passed.
- [x] Verified page navigation (Next / Previous) occurs instantaneously with zero network calls dispatched.
- [x] Verified changing a filter on Page 2+ triggers a fresh backend fetch and resets pagination safely.
