### PR TITLE
Improved: Renamed firebase project aliases to dev, uat and prod

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,7 +1,8 @@
 {
   "projects": {
-    "default": "hotwax-digital-commerce",
-    "production": "digital-commerce-71eb8"
+    "dev": "hotwax-digital-commerce",
+    "uat": "hotwax-digital-commerce",
+    "prod": "digital-commerce-71eb8"
   },
   "targets": {
     "digital-commerce-71eb8": {


### PR DESCRIPTION
Renames the firebase project aliases in `.firebaserc` from `default`/`production` to explicit `dev`, `uat` and `prod`, so the same alias names are used across all accxui apps for deploys.

No hosting targets or project ids changed.