### PR TITLE
feat(data-manager): make DataFeed state visible and editable

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -148,13 +148,13 @@ let appPages = [
     mdIcon: documentTextOutline,
     childRoutes: ["/data-documents/"]
   },
-  // {
-  //   title: "Feeds",
-  //   url: "/data-document-feeds",
-  //   iosIcon: gitNetworkOutline,
-  //   mdIcon: gitNetworkOutline,
-  //   childRoutes: ["/data-document-feeds/"]
-  // },
+  {
+    title: "Feeds",
+    url: "/data-document-feeds",
+    iosIcon: gitNetworkOutline,
+    mdIcon: gitNetworkOutline,
+    childRoutes: ["/data-document-feeds/"]
+  },
   {
     title: "Export History",
     url: "/data-document-export-history",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -170,19 +170,19 @@ const routes: Array<RouteRecordRaw> = [
     component: DataDocumentCatalog,
     beforeEnter: authGuard
   },
-  // {
-  //   path: '/data-document-feeds',
-  //   name: 'DataDocumentFeeds',
-  //   component: DataDocumentFeeds,
-  //   beforeEnter: authGuard
-  // },
-  // {
-  //   path: '/data-document-feeds/:id',
-  //   name: 'DataDocumentFeedDetail',
-  //   component: DataDocumentFeedDetail,
-  //   beforeEnter: authGuard,
-  //   props: true
-  // },
+  {
+    path: '/data-document-feeds',
+    name: 'DataDocumentFeeds',
+    component: DataDocumentFeeds,
+    beforeEnter: authGuard
+  },
+  {
+    path: '/data-document-feeds/:id',
+    name: 'DataDocumentFeedDetail',
+    component: DataDocumentFeedDetail,
+    beforeEnter: authGuard,
+    props: true
+  },
   {
     // Single detail page for a data document (also create via id="new"). Absorbs the former
     // detail / edit / run pages as in-page segments (Fields / Conditions / Preview / Usage /

--- a/src/views/ImportDetail.vue
+++ b/src/views/ImportDetail.vue
@@ -106,6 +106,17 @@
                     {{ config.multiThreading === "Y" ? translate("Yes") : translate("No") }}
                   </ion-label>
                 </ion-item>
+                <!-- Always rendered, unlike the optional fields above: an unset flag is the state
+                     worth seeing, because it silently suppresses every downstream event. -->
+                <ion-item>
+                  <ion-label class="ion-text-wrap">
+                    <p>{{ translate("Data Feed") }}</p>
+                    {{ isDataFeedEnabled ? translate("Enabled") : translate("Disabled") }}
+                  </ion-label>
+                  <ion-badge slot="end" :color="isDataFeedEnabled ? 'success' : 'medium'">
+                    {{ isDataFeedEnabled ? translate("On") : translate("Off") }}
+                  </ion-badge>
+                </ion-item>
                 <ion-item v-if="config.fileNamePattern">
                   <ion-label class="ion-text-wrap">
                     <p>{{ translate("File Name Pattern") }}</p>
@@ -133,6 +144,10 @@
                 </ion-select>
                 <ion-input :label="translate('File Name Pattern')" label-placement="stacked" fill="outline" :value="editForm.fileNamePattern" @ionInput="editForm.fileNamePattern = $event.detail.value || ''" />
                 <ion-input :label="translate('Import Path')" label-placement="stacked" fill="outline" :value="editForm.importPath" @ionInput="editForm.importPath = $event.detail.value || ''" />
+                <ion-select :label="translate('Data Feed')" label-placement="stacked" fill="outline" interface="popover" :value="editForm.enableDataFeed || 'N'" @ionChange="editForm.enableDataFeed = $event.detail.value" :helper-text="translate('When off, this import writes rows without raising Data Document events. Turn on only for imports whose writes must trigger downstream feeds.')">
+                  <ion-select-option value="Y">{{ translate("Enabled") }}</ion-select-option>
+                  <ion-select-option value="N">{{ translate("Disabled") }}</ion-select-option>
+                </ion-select>
               </ion-card-content>
             </ion-card>
 
@@ -193,6 +208,9 @@ const mdmStore = useMdmConfigStore();
 const jobStore = useJobStore();
 
 const config = computed(() => mdmStore.getConfigById(typeId));
+// The column defaults to "N" but existing rows predate it and hold null, so treat anything
+// other than an explicit "Y" as off - the same test isDataFeedEnabled() applies server side.
+const isDataFeedEnabled = computed(() => config.value.enableDataFeed === "Y");
 const executionModes = computed(() => mdmStore.getExecutionModes);
 const displayTitle = computed(() => config.value.description || config.value.scriptTitle || config.value.configId || typeId);
 
@@ -200,7 +218,7 @@ const isEditing = ref(false);
 const isSaving = ref(false);
 // Fields of DataManagerConfig that are safe to update from this screen; the
 // import service and config id stay read-only.
-const editableFields = ["description", "scriptTitle", "priority", "executionModeId", "multiThreading", "fileNamePattern", "importPath"];
+const editableFields = ["description", "scriptTitle", "priority", "executionModeId", "multiThreading", "fileNamePattern", "importPath", "enableDataFeed"];
 const editForm = reactive<Record<string, any>>({});
 
 const serviceParameters = ref<Array<any>>([]);

--- a/src/views/ManualUploads.vue
+++ b/src/views/ManualUploads.vue
@@ -15,6 +15,18 @@
 
         <ion-searchbar :value="queryString" @ionInput="queryString = ($event as any).detail.value || ''" :placeholder="translate('Search uploads')"></ion-searchbar>
 
+        <ion-segment class="feed-filter" :value="dataFeedFilter" @ionChange="dataFeedFilter = ($event as any).detail.value">
+          <ion-segment-button value="all">
+            <ion-label>{{ translate("All") }}</ion-label>
+          </ion-segment-button>
+          <ion-segment-button value="enabled">
+            <ion-label>{{ translate("Data feed on") }}</ion-label>
+          </ion-segment-button>
+          <ion-segment-button value="disabled">
+            <ion-label>{{ translate("Data feed off") }}</ion-label>
+          </ion-segment-button>
+        </ion-segment>
+
         <div class="empty-state" v-if="isLoading">
           <ion-item lines="none">
             <ion-spinner color="secondary" name="crescent" slot="start" />
@@ -30,6 +42,9 @@
                   {{ config.scriptTitle }}
                   <p>{{ config.description }}</p>
                 </ion-label>
+                <ion-badge slot="end" :color="isFeedOn(config) ? 'success' : 'medium'">
+                  {{ isFeedOn(config) ? translate("Feed on") : translate("Feed off") }}
+                </ion-badge>
               </ion-item>
               
               <ion-item lines="none">
@@ -51,26 +66,34 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { IonSpinner, IonPage, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonCard, IonCardContent, IonIcon, IonButton, IonSearchbar, IonLabel, IonItem, onIonViewWillEnter } from "@ionic/vue";
+import { IonSpinner, IonPage, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonCard, IonCardContent, IonIcon, IonButton, IonSearchbar, IonLabel, IonItem, IonBadge, IonSegment, IonSegmentButton, onIonViewWillEnter } from "@ionic/vue";
 import { arrowForwardOutline } from "ionicons/icons";
 import router from "@/router";
 import { translate } from "@common";
 import { useMdmConfigStore } from "@/store/mdmConfig";
 
 const queryString = ref("");
+const dataFeedFilter = ref("all");
 const mdmStore = useMdmConfigStore();
+
+// Mirrors the server-side isDataFeedEnabled() test: only an explicit "Y" counts as on, so the
+// many pre-existing configs holding null read as off rather than as unknown.
+const isFeedOn = (config: any) => config.enableDataFeed === "Y";
 
 const configs = computed(() => mdmStore.getConfigs);
 const isLoading = computed(() => mdmStore.getFetchStatus.configs === "pending");
 
+const matchesFeedFilter = (config: any) => dataFeedFilter.value === "all" ||
+  (dataFeedFilter.value === "enabled") === isFeedOn(config);
+
 const importConfigs = computed(() => {
   const q = queryString.value.trim().toLowerCase();
-  if (!q) return configs.value;
-  return configs.value.filter((config: any) =>
+  const matchesQuery = (config: any) => !q ||
     config.configId.toLowerCase().includes(q) ||
     config.scriptTitle?.toLowerCase().includes(q) ||
-    config.description?.toLowerCase().includes(q)
-  );
+    config.description?.toLowerCase().includes(q);
+
+  return configs.value.filter((config: any) => matchesFeedFilter(config) && matchesQuery(config));
 });
 
 onIonViewWillEnter(async () => {
@@ -86,6 +109,10 @@ const startImport = (typeId: string) => {
 
 <style scoped>
 
+
+.feed-filter {
+  margin-bottom: var(--spacer-xs);
+}
 
 .imports {
   display: grid;

--- a/src/views/ManualUploads.vue
+++ b/src/views/ManualUploads.vue
@@ -13,19 +13,30 @@
       <main>
 
 
-        <ion-searchbar :value="queryString" @ionInput="queryString = ($event as any).detail.value || ''" :placeholder="translate('Search uploads')"></ion-searchbar>
+        <ion-card>
+          <ion-card-content>
+            <ion-searchbar :value="queryString" @ionInput="queryString = ($event as any).detail.value || ''" :placeholder="translate('Search uploads')"></ion-searchbar>
 
-        <ion-segment class="feed-filter" :value="dataFeedFilter" @ionChange="dataFeedFilter = ($event as any).detail.value">
-          <ion-segment-button value="all">
-            <ion-label>{{ translate("All") }}</ion-label>
-          </ion-segment-button>
-          <ion-segment-button value="enabled">
-            <ion-label>{{ translate("Data feed on") }}</ion-label>
-          </ion-segment-button>
-          <ion-segment-button value="disabled">
-            <ion-label>{{ translate("Data feed off") }}</ion-label>
-          </ion-segment-button>
-        </ion-segment>
+            <div class="filter-grid">
+              <div class="filter-item">
+                <ion-select
+                  :label="translate('Data Feed')"
+                  label-placement="stacked"
+                  interface="popover"
+                  :placeholder="translate('All')"
+                  :value="dataFeedFilter"
+                  @ionChange="dataFeedFilter = $event.detail.value"
+                >
+                  <ion-select-option value="Y">{{ translate("Enabled") }}</ion-select-option>
+                  <ion-select-option value="N">{{ translate("Disabled") }}</ion-select-option>
+                </ion-select>
+                <ion-button v-if="dataFeedFilter" fill="clear" class="clear-filter-btn" @click="dataFeedFilter = ''" :title="translate('Clear')">
+                  <ion-icon slot="icon-only" :icon="closeCircleOutline" />
+                </ion-button>
+              </div>
+            </div>
+          </ion-card-content>
+        </ion-card>
 
         <div class="empty-state" v-if="isLoading">
           <ion-item lines="none">
@@ -66,14 +77,14 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { IonSpinner, IonPage, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonCard, IonCardContent, IonIcon, IonButton, IonSearchbar, IonLabel, IonItem, IonBadge, IonSegment, IonSegmentButton, onIonViewWillEnter } from "@ionic/vue";
-import { arrowForwardOutline } from "ionicons/icons";
+import { IonSpinner, IonPage, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonCard, IonCardContent, IonIcon, IonButton, IonSearchbar, IonLabel, IonItem, IonBadge, IonSelect, IonSelectOption, onIonViewWillEnter } from "@ionic/vue";
+import { arrowForwardOutline, closeCircleOutline } from "ionicons/icons";
 import router from "@/router";
 import { translate } from "@common";
 import { useMdmConfigStore } from "@/store/mdmConfig";
 
 const queryString = ref("");
-const dataFeedFilter = ref("all");
+const dataFeedFilter = ref("");
 const mdmStore = useMdmConfigStore();
 
 // Mirrors the server-side isDataFeedEnabled() test: only an explicit "Y" counts as on, so the
@@ -83,8 +94,8 @@ const isFeedOn = (config: any) => config.enableDataFeed === "Y";
 const configs = computed(() => mdmStore.getConfigs);
 const isLoading = computed(() => mdmStore.getFetchStatus.configs === "pending");
 
-const matchesFeedFilter = (config: any) => dataFeedFilter.value === "all" ||
-  (dataFeedFilter.value === "enabled") === isFeedOn(config);
+const matchesFeedFilter = (config: any) => !dataFeedFilter.value ||
+  (dataFeedFilter.value === "Y") === isFeedOn(config);
 
 const importConfigs = computed(() => {
   const q = queryString.value.trim().toLowerCase();
@@ -109,10 +120,6 @@ const startImport = (typeId: string) => {
 
 <style scoped>
 
-
-.feed-filter {
-  margin-bottom: var(--spacer-xs);
-}
 
 .imports {
   display: grid;


### PR DESCRIPTION
## Why

An MDM import runs with `EntityDataFeed` **disabled** unless its `DataManagerConfig` carries `enableDataFeed=Y`. The flag defaults off, is surfaced nowhere in the UI, and fails silently — rows import correctly while every downstream Data Document event is suppressed, with no error and no log line.

That is not hypothetical. On **Rails prod**, `NS_TO_RECEIPT_IMPORT` has `enableDataFeed` unset, so **7,467 transfer-order receipts over one week produced zero Shopify inventory adjustment events**. Only **2 of 30** import configs have the flag on. Nothing in the app could have shown that — it took a database query to find.

The flag is working as designed (`ScheduledDataManagerRunner.isDataFeedEnabled()` — bulk imports skip the feed for performance, opt in selectively). The gap is that its state is invisible.

## What changed

**1. Config detail — see and edit the flag**
`ImportDetail.vue` gains a Data Feed row and an Enabled/Disabled control. The row renders *unconditionally*, unlike the optional fields beside it, because an unset flag is exactly the state worth seeing. Helper text states the consequence rather than restating the field name.

**2. Manual Uploads — find the dark ones**
An `All / Data feed on / Data feed off` segment filter, plus a per-config badge so state is visible at a glance without opening each config.

**3. Data documents → Feeds — restored**
The `DataDocumentFeeds` / `DataDocumentFeedDetail` views already existed and were commented out in the router and menu. Re-enabled. They show feed type (`DTFDTP_RT_PUSH` vs `MAN_PULL`), attached documents, and `lastFeedStamp`.

> On feed stats: I checked the schema. `data_feed` holds only `LAST_FEED_STAMP` plus type and service names; `data_feed_document` is a pure join. There are **no run counts, volumes, or error tallies** to display. The restored view already surfaces all three signals that exist.

## Backend

No change needed — `admin/dataManager` uses generic entity `list`/`update` operations, so `enableDataFeed` (an audited field, `default="N"`) passes through already.

## Verification

- `vite build` passes
- Lint: **0 new errors**. 4 new warnings, each matching the established idiom in those files (`@ionInput`/`@ionChange`, single-line select options) — the edit form already does this on 20+ controls. Baseline was 241 problems, now 245.
- Unit tests: **identical to baseline** — 7 failed / 101 passed both with and without this change. All 7 pre-exist on `main` in `.claude/common/*` and two DataDocument specs.
- `/data-document-feeds` resolves (no Vue Router "No match found" warning); redirects to login via `authGuard` as intended.

**Not verified:** the pages behind login. I had no credentials and did not enter any, so the rendered config page, filter, and Feeds list have not been seen in a running authenticated app. Worth a reviewer clicking through.

## Follow-up worth considering

`enableDataFeed` is opt-in and silent when off. Even with this PR, a new import config defaults to dark. A warning when a config writes entities that belong to an active `DTFDTP_RT_PUSH` feed while its own flag is off would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)